### PR TITLE
feat: internal/jsonl パッケージ実装（JSONL parser）

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,16 @@
+name: test
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - run: go test ./...

--- a/cmd/run/main.go
+++ b/cmd/run/main.go
@@ -1,0 +1,22 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/rengotaku/claude-usage-tracker/internal/jsonl"
+)
+
+func main() {
+	dir := os.ExpandEnv("$HOME/.claude/projects")
+	start := time.Now()
+	entries, err := jsonl.Parse(dir)
+	elapsed := time.Since(start)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Printf("エントリ数: %d\n", len(entries))
+	fmt.Printf("処理時間: %s\n", elapsed)
+}

--- a/go.mod
+++ b/go.mod
@@ -1,0 +1,3 @@
+module github.com/rengotaku/claude-usage-tracker
+
+go 1.25.5

--- a/internal/jsonl/parser.go
+++ b/internal/jsonl/parser.go
@@ -71,36 +71,39 @@ func parseFile(path string, seen map[string]struct{}) ([]UsageEntry, error) {
 	defer f.Close()
 
 	var entries []UsageEntry
-	scanner := bufio.NewScanner(f)
-	scanner.Buffer(make([]byte, 1024*1024), 1024*1024)
+	reader := bufio.NewReader(f)
 
-	for scanner.Scan() {
-		line := scanner.Bytes()
-		var raw rawEntry
-		if err := json.Unmarshal(line, &raw); err != nil {
-			log.Printf("warn: skipping malformed line in %s: %v", path, err)
-			continue
+	for {
+		line, err := reader.ReadBytes('\n')
+		if len(line) > 0 {
+			var raw rawEntry
+			if jsonErr := json.Unmarshal(line, &raw); jsonErr != nil {
+				log.Printf("warn: skipping malformed line in %s: %v", path, jsonErr)
+			} else if raw.Type == "assistant" && raw.Message != nil && raw.Message.Usage != nil {
+				messageID := raw.Message.ID
+				if messageID == "" {
+					messageID = raw.UUID
+				}
+				if _, dup := seen[messageID]; !dup {
+					seen[messageID] = struct{}{}
+					entries = append(entries, UsageEntry{
+						MessageID:                messageID,
+						Timestamp:                raw.Timestamp,
+						Model:                    raw.Message.Model,
+						InputTokens:              raw.Message.Usage.InputTokens,
+						OutputTokens:             raw.Message.Usage.OutputTokens,
+						CacheCreationInputTokens: raw.Message.Usage.CacheCreationInputTokens,
+						CacheReadInputTokens:     raw.Message.Usage.CacheReadInputTokens,
+					})
+				}
+			}
 		}
-		if raw.Type != "assistant" || raw.Message == nil || raw.Message.Usage == nil {
-			continue
+		if err != nil {
+			if err.Error() == "EOF" {
+				break
+			}
+			return nil, err
 		}
-		messageID := raw.Message.ID
-		if messageID == "" {
-			messageID = raw.UUID
-		}
-		if _, dup := seen[messageID]; dup {
-			continue
-		}
-		seen[messageID] = struct{}{}
-		entries = append(entries, UsageEntry{
-			MessageID:                messageID,
-			Timestamp:                raw.Timestamp,
-			Model:                    raw.Message.Model,
-			InputTokens:              raw.Message.Usage.InputTokens,
-			OutputTokens:             raw.Message.Usage.OutputTokens,
-			CacheCreationInputTokens: raw.Message.Usage.CacheCreationInputTokens,
-			CacheReadInputTokens:     raw.Message.Usage.CacheReadInputTokens,
-		})
 	}
-	return entries, scanner.Err()
+	return entries, nil
 }

--- a/internal/jsonl/parser.go
+++ b/internal/jsonl/parser.go
@@ -1,0 +1,106 @@
+package jsonl
+
+import (
+	"bufio"
+	"encoding/json"
+	"io/fs"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+type UsageEntry struct {
+	MessageID                string
+	Timestamp                time.Time
+	Model                    string
+	InputTokens              int
+	OutputTokens             int
+	CacheCreationInputTokens int
+	CacheReadInputTokens     int
+}
+
+type rawEntry struct {
+	Type      string    `json:"type"`
+	UUID      string    `json:"uuid"`
+	Timestamp time.Time `json:"timestamp"`
+	Message   *struct {
+		ID    string `json:"id"`
+		Model string `json:"model"`
+		Usage *struct {
+			InputTokens              int `json:"input_tokens"`
+			OutputTokens             int `json:"output_tokens"`
+			CacheCreationInputTokens int `json:"cache_creation_input_tokens"`
+			CacheReadInputTokens     int `json:"cache_read_input_tokens"`
+		} `json:"usage"`
+	} `json:"message"`
+}
+
+// Parse walks dir and returns all unique UsageEntry records found in .jsonl files.
+func Parse(dir string) ([]UsageEntry, error) {
+	seen := make(map[string]struct{})
+	var entries []UsageEntry
+
+	err := filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if d.IsDir() || !strings.HasSuffix(path, ".jsonl") {
+			return nil
+		}
+		fileEntries, fileErr := parseFile(path, seen)
+		if fileErr != nil {
+			log.Printf("warn: skipping file %s: %v", path, fileErr)
+			return nil
+		}
+		entries = append(entries, fileEntries...)
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return entries, nil
+}
+
+func parseFile(path string, seen map[string]struct{}) ([]UsageEntry, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	var entries []UsageEntry
+	scanner := bufio.NewScanner(f)
+	scanner.Buffer(make([]byte, 1024*1024), 1024*1024)
+
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		var raw rawEntry
+		if err := json.Unmarshal(line, &raw); err != nil {
+			log.Printf("warn: skipping malformed line in %s: %v", path, err)
+			continue
+		}
+		if raw.Type != "assistant" || raw.Message == nil || raw.Message.Usage == nil {
+			continue
+		}
+		messageID := raw.Message.ID
+		if messageID == "" {
+			messageID = raw.UUID
+		}
+		if _, dup := seen[messageID]; dup {
+			continue
+		}
+		seen[messageID] = struct{}{}
+		entries = append(entries, UsageEntry{
+			MessageID:                messageID,
+			Timestamp:                raw.Timestamp,
+			Model:                    raw.Message.Model,
+			InputTokens:              raw.Message.Usage.InputTokens,
+			OutputTokens:             raw.Message.Usage.OutputTokens,
+			CacheCreationInputTokens: raw.Message.Usage.CacheCreationInputTokens,
+			CacheReadInputTokens:     raw.Message.Usage.CacheReadInputTokens,
+		})
+	}
+	return entries, scanner.Err()
+}

--- a/internal/jsonl/parser_test.go
+++ b/internal/jsonl/parser_test.go
@@ -1,0 +1,89 @@
+package jsonl_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/rengotaku/claude-usage-tracker/internal/jsonl"
+)
+
+func TestParse_ReturnsUsageEntries(t *testing.T) {
+	entries, err := jsonl.Parse("testdata")
+	if err != nil {
+		t.Fatalf("Parse returned error: %v", err)
+	}
+
+	// sample.jsonl has 2 unique assistant messages with usage (msg_001 deduped)
+	if len(entries) != 2 {
+		t.Errorf("expected 2 entries, got %d", len(entries))
+	}
+}
+
+func TestParse_FieldValues(t *testing.T) {
+	entries, err := jsonl.Parse("testdata")
+	if err != nil {
+		t.Fatalf("Parse returned error: %v", err)
+	}
+	if len(entries) < 1 {
+		t.Fatal("no entries returned")
+	}
+
+	e := entries[0]
+	if e.MessageID != "msg_001" {
+		t.Errorf("MessageID: want msg_001, got %s", e.MessageID)
+	}
+	if e.Model != "claude-sonnet-4-6" {
+		t.Errorf("Model: want claude-sonnet-4-6, got %s", e.Model)
+	}
+	if e.InputTokens != 10 {
+		t.Errorf("InputTokens: want 10, got %d", e.InputTokens)
+	}
+	if e.OutputTokens != 20 {
+		t.Errorf("OutputTokens: want 20, got %d", e.OutputTokens)
+	}
+	if e.CacheCreationInputTokens != 100 {
+		t.Errorf("CacheCreationInputTokens: want 100, got %d", e.CacheCreationInputTokens)
+	}
+	if e.CacheReadInputTokens != 50 {
+		t.Errorf("CacheReadInputTokens: want 50, got %d", e.CacheReadInputTokens)
+	}
+	want := time.Date(2026, 4, 18, 8, 0, 1, 0, time.UTC)
+	if !e.Timestamp.Equal(want) {
+		t.Errorf("Timestamp: want %v, got %v", want, e.Timestamp)
+	}
+}
+
+func TestParse_Deduplication(t *testing.T) {
+	// msg_001 appears twice in testdata/sample.jsonl; should only count once
+	entries, err := jsonl.Parse("testdata")
+	if err != nil {
+		t.Fatalf("Parse returned error: %v", err)
+	}
+	seen := make(map[string]int)
+	for _, e := range entries {
+		seen[e.MessageID]++
+	}
+	for id, count := range seen {
+		if count > 1 {
+			t.Errorf("duplicate entry for MessageID %s: count=%d", id, count)
+		}
+	}
+}
+
+func TestParse_NonExistentDir(t *testing.T) {
+	_, err := jsonl.Parse("/nonexistent/path/that/does/not/exist")
+	if err == nil {
+		t.Error("expected error for non-existent directory, got nil")
+	}
+}
+
+func TestParse_SkipsMalformedLines(t *testing.T) {
+	// sample.jsonl contains one malformed line; Parse should not return error
+	entries, err := jsonl.Parse("testdata")
+	if err != nil {
+		t.Fatalf("Parse should not error on malformed lines, got: %v", err)
+	}
+	if len(entries) == 0 {
+		t.Error("expected entries despite malformed lines")
+	}
+}

--- a/internal/jsonl/testdata/sample.jsonl
+++ b/internal/jsonl/testdata/sample.jsonl
@@ -1,0 +1,6 @@
+{"type":"user","uuid":"uuid-001","timestamp":"2026-04-18T08:00:00.000Z","message":{"role":"user","content":"hello"}}
+{"type":"assistant","uuid":"uuid-002","timestamp":"2026-04-18T08:00:01.000Z","message":{"id":"msg_001","model":"claude-sonnet-4-6","role":"assistant","content":[],"usage":{"input_tokens":10,"output_tokens":20,"cache_creation_input_tokens":100,"cache_read_input_tokens":50}}}
+{"type":"assistant","uuid":"uuid-003","timestamp":"2026-04-18T08:01:00.000Z","message":{"id":"msg_002","model":"claude-haiku-4-5","role":"assistant","content":[],"usage":{"input_tokens":5,"output_tokens":15,"cache_creation_input_tokens":0,"cache_read_input_tokens":200}}}
+{"type":"assistant","uuid":"uuid-004","timestamp":"2026-04-18T08:02:00.000Z","message":{"id":"msg_001","model":"claude-sonnet-4-6","role":"assistant","content":[],"usage":{"input_tokens":10,"output_tokens":20,"cache_creation_input_tokens":100,"cache_read_input_tokens":50}}}
+{"INVALID_JSON
+{"type":"file-history-snapshot","messageId":"snap-001","snapshot":{}}


### PR DESCRIPTION
## 概要

Issue #2 の実装。`~/.claude/projects/**/*.jsonl` を走査して Claude Code トランスクリプトから token 使用情報を抽出する `internal/jsonl` パッケージを追加。

## 変更内容

- `go.mod` — Goモジュール初期化 (`github.com/rengotaku/claude-usage-tracker`)
- `internal/jsonl/parser.go` — `Parse(dir string) ([]UsageEntry, error)` の実装
  - `filepath.WalkDir` で `.jsonl` ファイルを再帰的に列挙
  - `type: "assistant"` かつ `message.usage` が存在する行のみ抽出
  - 破損行はスキップ（警告ログ出力）
  - `message.id` による重複排除
- `internal/jsonl/testdata/sample.jsonl` — テスト用サンプルデータ
- `internal/jsonl/parser_test.go` — ユニットテスト5件

## テスト結果

- TestParse_ReturnsUsageEntries — 正常系: 2件返却（重複排除済み）
- TestParse_FieldValues — 各フィールドの値検証
- TestParse_Deduplication — 同一 message ID の重複排除
- TestParse_NonExistentDir — 存在しないディレクトリでエラー返却
- TestParse_SkipsMalformedLines — 破損行をスキップしてもエラーにならない

全テスト通過: ok github.com/rengotaku/claude-usage-tracker/internal/jsonl 0.005s

Closes #2
