### PR TITLE
feat: 5時間ブロック集計ロジック実装（internal/blocks）

### DIFF
--- a/internal/blocks/blocks.go
+++ b/internal/blocks/blocks.go
@@ -1,0 +1,76 @@
+package blocks
+
+import (
+	"sort"
+	"time"
+
+	"github.com/rengotaku/claude-usage-tracker/internal/jsonl"
+)
+
+const blockDuration = 5 * time.Hour
+
+// Block represents a 5-hour billing period.
+type Block struct {
+	StartTime   time.Time
+	EndTime     time.Time
+	IsActive    bool
+	TotalTokens int
+	EntryCount  int
+}
+
+// Build converts a slice of UsageEntry into 5-hour blocks sorted by StartTime.
+func Build(entries []jsonl.UsageEntry) []Block {
+	if len(entries) == 0 {
+		return nil
+	}
+
+	sorted := make([]jsonl.UsageEntry, len(entries))
+	copy(sorted, entries)
+	sort.Slice(sorted, func(i, j int) bool {
+		return sorted[i].Timestamp.Before(sorted[j].Timestamp)
+	})
+
+	var blocks []Block
+	var current *Block
+
+	for _, e := range sorted {
+		if current == nil || !e.Timestamp.Before(current.EndTime) {
+			start := floorToHour(e.Timestamp.UTC())
+			b := Block{
+				StartTime: start,
+				EndTime:   start.Add(blockDuration),
+			}
+			blocks = append(blocks, b)
+			current = &blocks[len(blocks)-1]
+		}
+		current.TotalTokens += totalTokens(e)
+		current.EntryCount++
+	}
+
+	now := time.Now().UTC()
+	for i := range blocks {
+		if !now.Before(blocks[i].StartTime) && now.Before(blocks[i].EndTime) {
+			blocks[i].IsActive = true
+		}
+	}
+
+	return blocks
+}
+
+// ActiveBlock returns the currently active block, or nil if none is active.
+func ActiveBlock(blocks []Block) *Block {
+	for i := range blocks {
+		if blocks[i].IsActive {
+			return &blocks[i]
+		}
+	}
+	return nil
+}
+
+func floorToHour(t time.Time) time.Time {
+	return time.Date(t.Year(), t.Month(), t.Day(), t.Hour(), 0, 0, 0, time.UTC)
+}
+
+func totalTokens(e jsonl.UsageEntry) int {
+	return e.InputTokens + e.OutputTokens + e.CacheCreationInputTokens + e.CacheReadInputTokens
+}

--- a/internal/blocks/blocks_test.go
+++ b/internal/blocks/blocks_test.go
@@ -1,0 +1,140 @@
+package blocks_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/rengotaku/claude-usage-tracker/internal/blocks"
+	"github.com/rengotaku/claude-usage-tracker/internal/jsonl"
+)
+
+func entry(ts time.Time, input, output, cacheCreate, cacheRead int) jsonl.UsageEntry {
+	return jsonl.UsageEntry{
+		Timestamp:                ts,
+		InputTokens:              input,
+		OutputTokens:             output,
+		CacheCreationInputTokens: cacheCreate,
+		CacheReadInputTokens:     cacheRead,
+	}
+}
+
+func utc(year int, month time.Month, day, hour, min int) time.Time {
+	return time.Date(year, month, day, hour, min, 0, 0, time.UTC)
+}
+
+func TestBuild_EmptyEntries(t *testing.T) {
+	result := blocks.Build(nil)
+	if result != nil {
+		t.Errorf("expected nil, got %v", result)
+	}
+}
+
+func TestBuild_SingleEntry(t *testing.T) {
+	entries := []jsonl.UsageEntry{
+		entry(utc(2026, 4, 19, 10, 30), 10, 20, 5, 3),
+	}
+	result := blocks.Build(entries)
+	if len(result) != 1 {
+		t.Fatalf("expected 1 block, got %d", len(result))
+	}
+	b := result[0]
+	// floorToHour: 10:30 → 10:00
+	want := utc(2026, 4, 19, 10, 0)
+	if !b.StartTime.Equal(want) {
+		t.Errorf("StartTime: want %v, got %v", want, b.StartTime)
+	}
+	if !b.EndTime.Equal(want.Add(5 * time.Hour)) {
+		t.Errorf("EndTime: want %v, got %v", want.Add(5*time.Hour), b.EndTime)
+	}
+	if b.TotalTokens != 38 {
+		t.Errorf("TotalTokens: want 38, got %d", b.TotalTokens)
+	}
+	if b.EntryCount != 1 {
+		t.Errorf("EntryCount: want 1, got %d", b.EntryCount)
+	}
+}
+
+func TestBuild_EntriesWithinSameBlock(t *testing.T) {
+	entries := []jsonl.UsageEntry{
+		entry(utc(2026, 4, 19, 10, 0), 10, 10, 0, 0),
+		entry(utc(2026, 4, 19, 12, 0), 20, 20, 0, 0),
+		entry(utc(2026, 4, 19, 14, 59), 5, 5, 0, 0),
+	}
+	result := blocks.Build(entries)
+	if len(result) != 1 {
+		t.Fatalf("expected 1 block, got %d", len(result))
+	}
+	if result[0].EntryCount != 3 {
+		t.Errorf("EntryCount: want 3, got %d", result[0].EntryCount)
+	}
+	if result[0].TotalTokens != 70 {
+		t.Errorf("TotalTokens: want 70, got %d", result[0].TotalTokens)
+	}
+}
+
+func TestBuild_ExactlyAtBlockBoundary(t *testing.T) {
+	// 10:00 → block [10:00, 15:00); entry at 15:00 starts new block
+	entries := []jsonl.UsageEntry{
+		entry(utc(2026, 4, 19, 10, 0), 10, 0, 0, 0),
+		entry(utc(2026, 4, 19, 15, 0), 20, 0, 0, 0),
+	}
+	result := blocks.Build(entries)
+	if len(result) != 2 {
+		t.Fatalf("expected 2 blocks, got %d", len(result))
+	}
+	if result[0].TotalTokens != 10 {
+		t.Errorf("block[0] TotalTokens: want 10, got %d", result[0].TotalTokens)
+	}
+	if result[1].TotalTokens != 20 {
+		t.Errorf("block[1] TotalTokens: want 20, got %d", result[1].TotalTokens)
+	}
+}
+
+func TestBuild_GapBetweenBlocks(t *testing.T) {
+	entries := []jsonl.UsageEntry{
+		entry(utc(2026, 4, 19, 10, 0), 10, 0, 0, 0),
+		// 24-hour gap
+		entry(utc(2026, 4, 20, 10, 0), 20, 0, 0, 0),
+	}
+	result := blocks.Build(entries)
+	if len(result) != 2 {
+		t.Fatalf("expected 2 blocks, got %d", len(result))
+	}
+}
+
+func TestBuild_UnsortedEntriesAreSorted(t *testing.T) {
+	entries := []jsonl.UsageEntry{
+		entry(utc(2026, 4, 19, 14, 0), 20, 0, 0, 0),
+		entry(utc(2026, 4, 19, 10, 0), 10, 0, 0, 0),
+	}
+	result := blocks.Build(entries)
+	if len(result) != 1 {
+		t.Fatalf("expected 1 block, got %d", len(result))
+	}
+	if result[0].EntryCount != 2 {
+		t.Errorf("EntryCount: want 2, got %d", result[0].EntryCount)
+	}
+}
+
+func TestActiveBlock_NilWhenNoActive(t *testing.T) {
+	bs := []blocks.Block{
+		{StartTime: utc(2020, 1, 1, 0, 0), EndTime: utc(2020, 1, 1, 5, 0), IsActive: false},
+	}
+	if blocks.ActiveBlock(bs) != nil {
+		t.Error("expected nil ActiveBlock")
+	}
+}
+
+func TestActiveBlock_ReturnsActive(t *testing.T) {
+	bs := []blocks.Block{
+		{StartTime: utc(2020, 1, 1, 0, 0), EndTime: utc(2020, 1, 1, 5, 0), IsActive: false},
+		{StartTime: utc(2020, 1, 1, 5, 0), EndTime: utc(2020, 1, 1, 10, 0), IsActive: true},
+	}
+	got := blocks.ActiveBlock(bs)
+	if got == nil {
+		t.Fatal("expected non-nil ActiveBlock")
+	}
+	if !got.IsActive {
+		t.Error("returned block is not active")
+	}
+}


### PR DESCRIPTION
## 概要

Issue #3 の実装。`[]UsageEntry` を5時間単位の課金ブロック（`[]Block`）に変換する `internal/blocks` パッケージを追加。ccusage の `src/_session-blocks.ts` 相当のロジックを Go で再実装。

## 変更内容

- `internal/blocks/blocks.go` — `Build()` / `ActiveBlock()` API の実装
  - エントリを時系列ソート
  - `floorToHour`（UTC 時刻の頭に切り捨て）でブロック開始時刻を確定
  - ブロック幅: 5時間固定
  - `tokens_used` = `input + output + cache_creation + cache_read` 全合算（ccusage 準拠）
  - `ActiveBlock()` で現在時刻を含むブロックを返す
- `internal/blocks/blocks_test.go` — ユニットテスト8件

## テスト結果

- TestBuild_EmptyEntries — nil 入力
- TestBuild_SingleEntry — floorToHour・StartTime/EndTime・TotalTokens 検証
- TestBuild_EntriesWithinSameBlock — 同一ブロック内複数エントリ
- TestBuild_ExactlyAtBlockBoundary — ちょうど5時間で新ブロック開始
- TestBuild_GapBetweenBlocks — 24時間ギャップで別ブロック
- TestBuild_UnsortedEntriesAreSorted — 順序不定入力の自動ソート
- TestActiveBlock_NilWhenNoActive — アクティブブロックなし
- TestActiveBlock_ReturnsActive — アクティブブロック取得

全テスト通過: ok github.com/rengotaku/claude-usage-tracker/internal/blocks 0.002s

Closes #3
