### PR TITLE
feat: cmd/snapshot・cmd/current CLIとservice層を実装

### DIFF
--- a/cmd/current/main.go
+++ b/cmd/current/main.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"os"
+
+	"github.com/rengotaku/claude-usage-tracker/internal/service"
+)
+
+type jsonOutput struct {
+	TokensUsed    int     `json:"tokens_used"`
+	PlanLimit     int     `json:"plan_limit"`
+	UsageRatio    float64 `json:"usage_ratio"`
+	BlockStartsAt string  `json:"block_starts_at,omitempty"`
+	BlockEndsAt   string  `json:"block_ends_at,omitempty"`
+}
+
+func main() {
+	logger := slog.New(slog.NewJSONHandler(os.Stderr, nil))
+
+	jsonFlag := len(os.Args) > 1 && os.Args[1] == "--json"
+
+	cfg := service.ConfigFromEnv()
+	result, err := service.Compute(cfg)
+	if err != nil {
+		logger.Error("compute usage", "error", err)
+		os.Exit(1)
+	}
+
+	if jsonFlag {
+		out := jsonOutput{
+			TokensUsed: result.TokensUsed,
+			PlanLimit:  result.PlanLimit,
+			UsageRatio: result.UsageRatio,
+		}
+		if result.ActiveBlock != nil {
+			out.BlockStartsAt = result.ActiveBlock.StartTime.Format("2006-01-02T15:04:05Z")
+			out.BlockEndsAt = result.ActiveBlock.EndTime.Format("2006-01-02T15:04:05Z")
+		}
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		if err := enc.Encode(out); err != nil {
+			logger.Error("encode json", "error", err)
+			os.Exit(1)
+		}
+		return
+	}
+
+	pct := result.UsageRatio * 100
+	usedM := float64(result.TokensUsed) / 1_000_000
+	limitM := float64(result.PlanLimit) / 1_000_000
+
+	if result.ActiveBlock == nil {
+		fmt.Printf("%.1f%% (tokens: %.0fM / %.0fM, no active block)\n", pct, usedM, limitM)
+		return
+	}
+
+	blockEnds := result.ActiveBlock.EndTime.Format("2006-01-02T15:04:05Z")
+	fmt.Printf("%.1f%% (tokens: %.0fM / %.0fM, block ends at %s)\n", pct, usedM, limitM, blockEnds)
+}

--- a/cmd/snapshot/main.go
+++ b/cmd/snapshot/main.go
@@ -1,0 +1,54 @@
+package main
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"time"
+
+	"github.com/rengotaku/claude-usage-tracker/internal/repository"
+	"github.com/rengotaku/claude-usage-tracker/internal/service"
+)
+
+func main() {
+	logger := slog.New(slog.NewJSONHandler(os.Stderr, nil))
+
+	cfg := service.ConfigFromEnv()
+	result, err := service.Compute(cfg)
+	if err != nil {
+		logger.Error("compute usage", "error", err)
+		os.Exit(1)
+	}
+
+	dbPath := repository.DBPath()
+	repo, err := repository.NewSnapshotRepository(context.Background(), dbPath)
+	if err != nil {
+		logger.Error("open repository", "path", dbPath, "error", err)
+		os.Exit(1)
+	}
+	defer repo.Close()
+
+	snap := repository.Snapshot{
+		TakenAt:    time.Now().UTC(),
+		TokensUsed: result.TokensUsed,
+		UsageRatio: result.UsageRatio,
+	}
+	if result.ActiveBlock != nil {
+		snap.BlockStartedAt = result.ActiveBlock.StartTime
+		endTime := result.ActiveBlock.EndTime
+		snap.BlockEndedAt = &endTime
+	} else {
+		snap.BlockStartedAt = time.Now().UTC()
+	}
+
+	if err := repo.Save(context.Background(), snap); err != nil {
+		logger.Error("save snapshot", "error", err)
+		os.Exit(1)
+	}
+
+	logger.Info("snapshot saved",
+		"tokens_used", result.TokensUsed,
+		"plan_limit", result.PlanLimit,
+		"usage_ratio", result.UsageRatio,
+	)
+}

--- a/internal/service/usage.go
+++ b/internal/service/usage.go
@@ -1,0 +1,68 @@
+package service
+
+import (
+	"fmt"
+	"os"
+	"strconv"
+
+	"github.com/rengotaku/claude-usage-tracker/internal/blocks"
+	"github.com/rengotaku/claude-usage-tracker/internal/jsonl"
+)
+
+const defaultPlanLimit = 200_000_000
+
+// Config holds runtime configuration for usage computation.
+type Config struct {
+	LogDir    string
+	PlanLimit int
+}
+
+// ConfigFromEnv builds Config from environment variables with defaults.
+func ConfigFromEnv() Config {
+	logDir := os.Getenv("CLAUDE_USAGE_TRACKER_LOG_DIR")
+	if logDir == "" {
+		home, _ := os.UserHomeDir()
+		logDir = home + "/.claude/projects"
+	}
+
+	planLimit := defaultPlanLimit
+	if v := os.Getenv("CLAUDE_USAGE_TRACKER_PLAN_LIMIT"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			planLimit = n
+		}
+	}
+
+	return Config{LogDir: logDir, PlanLimit: planLimit}
+}
+
+// UsageResult is the computed usage for the current billing block.
+type UsageResult struct {
+	TokensUsed  int
+	PlanLimit   int
+	UsageRatio  float64
+	ActiveBlock *blocks.Block
+}
+
+// Compute parses JSONL logs and returns current block usage.
+// If no active block exists, TokensUsed and UsageRatio are zero.
+func Compute(cfg Config) (*UsageResult, error) {
+	if cfg.PlanLimit <= 0 {
+		return nil, fmt.Errorf("plan_limit must be positive")
+	}
+
+	entries, err := jsonl.Parse(cfg.LogDir)
+	if err != nil {
+		return nil, fmt.Errorf("parse logs: %w", err)
+	}
+
+	bs := blocks.Build(entries)
+	active := blocks.ActiveBlock(bs)
+
+	result := &UsageResult{PlanLimit: cfg.PlanLimit}
+	if active != nil {
+		result.TokensUsed = active.TotalTokens
+		result.UsageRatio = float64(active.TotalTokens) / float64(cfg.PlanLimit)
+		result.ActiveBlock = active
+	}
+	return result, nil
+}

--- a/internal/service/usage_test.go
+++ b/internal/service/usage_test.go
@@ -1,0 +1,96 @@
+package service_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/rengotaku/claude-usage-tracker/internal/service"
+)
+
+func TestCompute_NoEntries(t *testing.T) {
+	dir := t.TempDir()
+	cfg := service.Config{LogDir: dir, PlanLimit: 1_000_000}
+
+	result, err := service.Compute(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.TokensUsed != 0 {
+		t.Errorf("expected 0 tokens, got %d", result.TokensUsed)
+	}
+	if result.UsageRatio != 0 {
+		t.Errorf("expected 0 ratio, got %f", result.UsageRatio)
+	}
+	if result.ActiveBlock != nil {
+		t.Error("expected no active block")
+	}
+}
+
+func TestCompute_ActiveBlock(t *testing.T) {
+	dir := t.TempDir()
+	now := time.Now().UTC()
+	writeJSONL(t, dir, now)
+
+	cfg := service.Config{LogDir: dir, PlanLimit: 1_000_000}
+	result, err := service.Compute(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if result.ActiveBlock == nil {
+		t.Fatal("expected active block")
+	}
+	// input(100) + output(200) = 300
+	if result.TokensUsed != 300 {
+		t.Errorf("expected 300 tokens, got %d", result.TokensUsed)
+	}
+	want := float64(300) / float64(1_000_000)
+	if result.UsageRatio != want {
+		t.Errorf("expected ratio %f, got %f", want, result.UsageRatio)
+	}
+}
+
+func TestCompute_InvalidPlanLimit(t *testing.T) {
+	cfg := service.Config{LogDir: t.TempDir(), PlanLimit: 0}
+	_, err := service.Compute(cfg)
+	if err == nil {
+		t.Error("expected error for zero plan_limit")
+	}
+}
+
+func TestConfigFromEnv_Defaults(t *testing.T) {
+	t.Setenv("CLAUDE_USAGE_TRACKER_LOG_DIR", "")
+	t.Setenv("CLAUDE_USAGE_TRACKER_PLAN_LIMIT", "")
+
+	cfg := service.ConfigFromEnv()
+	if cfg.PlanLimit != 200_000_000 {
+		t.Errorf("expected default plan limit 200_000_000, got %d", cfg.PlanLimit)
+	}
+	if cfg.LogDir == "" {
+		t.Error("expected non-empty log dir")
+	}
+}
+
+func TestConfigFromEnv_EnvOverride(t *testing.T) {
+	t.Setenv("CLAUDE_USAGE_TRACKER_LOG_DIR", "/tmp/logs")
+	t.Setenv("CLAUDE_USAGE_TRACKER_PLAN_LIMIT", "500000")
+
+	cfg := service.ConfigFromEnv()
+	if cfg.LogDir != "/tmp/logs" {
+		t.Errorf("expected /tmp/logs, got %s", cfg.LogDir)
+	}
+	if cfg.PlanLimit != 500_000 {
+		t.Errorf("expected 500000, got %d", cfg.PlanLimit)
+	}
+}
+
+func writeJSONL(t *testing.T, dir string, ts time.Time) {
+	t.Helper()
+	line := `{"type":"assistant","uuid":"u1","timestamp":"` + ts.Format(time.RFC3339) + `","message":{"id":"msg1","model":"claude-sonnet-4-6","usage":{"input_tokens":100,"output_tokens":200,"cache_creation_input_tokens":0,"cache_read_input_tokens":0}}}` + "\n"
+	path := filepath.Join(dir, "test.jsonl")
+	if err := os.WriteFile(path, []byte(line), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}


### PR DESCRIPTION
Closes #5

## 概要

- `internal/service/usage.go` — ビジネスロジックを集約したサービス層を実装
- `cmd/snapshot/main.go` — systemd timer から叩かれる CLI。使用率を計算して SQLite に保存
- `cmd/current/main.go` — 現在の使用率を stdout に出力するワンショット CLI（`--json` フラグ対応）

## 変更内容

### internal/service

- `Config` / `ConfigFromEnv()` — 環境変数（`CLAUDE_USAGE_TRACKER_LOG_DIR`, `CLAUDE_USAGE_TRACKER_PLAN_LIMIT`）から設定を読み込み
- `Compute(cfg)` — JSONL パース → ブロック集計 → UsageRatio 計算

### cmd/snapshot

- `service.Compute` で使用率を算出し `repository.SnapshotRepository` に保存
- 構造化ログ（`log/slog` JSON）、失敗時は非ゼロ終了

### cmd/current

- デフォルト: `6.5% (tokens: 13M / 200M, block ends at 2026-04-19T11:00:00Z)`
- `--json` フラグ: JSON 出力

## テスト

- `internal/service` ユニットテスト 5件（全 PASS）
- スモークテスト: `go run ./cmd/current` / `go run ./cmd/snapshot` 動作確認済み
