### PR TITLE
feat: systemd timer/service 整備

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build test lint clean
+.PHONY: build test lint clean install uninstall status
 
 build:
 	CGO_ENABLED=0 go build ./...
@@ -11,3 +11,15 @@ lint:
 
 clean:
 	go clean ./...
+
+install:
+	bash deploy/systemd/install.sh
+
+uninstall:
+	systemctl --user disable --now claude-usage-tracker.timer || true
+	rm -f ~/.config/systemd/user/claude-usage-tracker.{service,timer}
+	rm -f ~/.local/bin/claude-usage-tracker-{snapshot,current}
+	systemctl --user daemon-reload
+
+status:
+	systemctl --user status claude-usage-tracker.timer claude-usage-tracker.service

--- a/Makefile
+++ b/Makefile
@@ -22,4 +22,4 @@ uninstall:
 	systemctl --user daemon-reload
 
 status:
-	systemctl --user status claude-usage-tracker.timer claude-usage-tracker.service
+	systemctl --user status claude-usage-tracker.timer claude-usage-tracker.service || true

--- a/README.md
+++ b/README.md
@@ -1,2 +1,41 @@
 # claude-usage-tracker
+
 Claudeのusage状態を定期的に記録するリポジトリ
+
+## コマンド
+
+| コマンド | 説明 |
+|---|---|
+| `claude-usage-tracker-current` | 現在の使用率を表示（`--json` で JSON 出力） |
+| `claude-usage-tracker-snapshot` | 使用率を計測して SQLite に保存 |
+
+## 環境変数
+
+| 変数 | デフォルト | 説明 |
+|---|---|---|
+| `CLAUDE_USAGE_TRACKER_LOG_DIR` | `~/.claude/projects` | JSONL ログディレクトリ |
+| `CLAUDE_USAGE_TRACKER_PLAN_LIMIT` | `200000000` | プランのトークン上限 |
+| `CLAUDE_USAGE_TRACKER_DB` | `~/.local/share/claude-usage-tracker/snapshots.db` | SQLite DB パス |
+
+## インストール（systemd timer）
+
+```bash
+make install
+```
+
+- バイナリを `~/.local/bin/` に配置
+- user-level systemd timer を有効化（毎時実行）
+
+### 確認
+
+```bash
+systemctl --user list-timers
+# または
+make status
+```
+
+### アンインストール
+
+```bash
+make uninstall
+```

--- a/deploy/systemd/claude-usage-tracker.service
+++ b/deploy/systemd/claude-usage-tracker.service
@@ -1,0 +1,8 @@
+[Unit]
+Description=Claude usage snapshot
+After=network.target
+
+[Service]
+Type=oneshot
+Environment=CLAUDE_USAGE_TRACKER_DB_PATH=%h/.local/share/claude-usage-tracker/snapshots.db
+ExecStart=%h/.local/bin/claude-usage-tracker-snapshot

--- a/deploy/systemd/claude-usage-tracker.timer
+++ b/deploy/systemd/claude-usage-tracker.timer
@@ -1,0 +1,9 @@
+[Unit]
+Description=Claude usage snapshot timer
+
+[Timer]
+OnCalendar=hourly
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/install.sh
+++ b/deploy/systemd/install.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+BIN_DIR="$HOME/.local/bin"
+UNIT_DIR="$HOME/.config/systemd/user"
+
+mkdir -p "$BIN_DIR" "$UNIT_DIR"
+
+echo "Building binaries..."
+cd "$SCRIPT_DIR/../.."
+CGO_ENABLED=0 go build -o "$BIN_DIR/claude-usage-tracker-snapshot" ./cmd/snapshot
+CGO_ENABLED=0 go build -o "$BIN_DIR/claude-usage-tracker-current" ./cmd/current
+
+echo "Installing systemd units..."
+cp "$SCRIPT_DIR/claude-usage-tracker.service" "$UNIT_DIR/"
+cp "$SCRIPT_DIR/claude-usage-tracker.timer"   "$UNIT_DIR/"
+
+systemctl --user daemon-reload
+systemctl --user enable --now claude-usage-tracker.timer
+
+echo "Done. Verify with: systemctl --user list-timers"


### PR DESCRIPTION
Closes #6

## 概要

- `deploy/systemd/claude-usage-tracker.service` — oneshot service ユニット
- `deploy/systemd/claude-usage-tracker.timer` — hourly timer ユニット（Persistent=true）
- `deploy/systemd/install.sh` — ビルド・配置・timer 有効化を一括実行
- `Makefile` — `install` / `uninstall` / `status` ターゲット追加
- `README.md` — 環境変数・インストール手順を記載

## 使い方

```bash
make install
systemctl --user list-timers   # hourly 登録確認
make status                    # service/timer 状態確認
make uninstall                 # 削除
```
