### PR TITLE
feat: JST統一・週次使用量表示・SQLite週次カラム追加

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build test lint clean install uninstall status
+.PHONY: build test lint clean install uninstall status db
 
 build:
 	CGO_ENABLED=0 go build ./...
@@ -23,3 +23,7 @@ uninstall:
 
 status:
 	systemctl --user status claude-usage-tracker.timer claude-usage-tracker.service || true
+
+DB_PATH ?= $(HOME)/.local/share/claude-usage-tracker/snapshots.db
+db:
+	sqlite3 $(DB_PATH) "SELECT datetime(taken_at,'+9 hours')||'+09:00' AS taken_at_jst, datetime(block_started_at,'+9 hours')||'+09:00' AS block_started_jst, CASE WHEN block_ended_at IS NOT NULL THEN datetime(block_ended_at,'+9 hours')||'+09:00' END AS block_ended_jst, tokens_used, usage_ratio FROM snapshots ORDER BY taken_at DESC LIMIT 10;"

--- a/Makefile
+++ b/Makefile
@@ -26,4 +26,4 @@ status:
 
 DB_PATH ?= $(HOME)/.local/share/claude-usage-tracker/snapshots.db
 db:
-	sqlite3 $(DB_PATH) "SELECT datetime(taken_at,'+9 hours')||'+09:00' AS taken_at_jst, datetime(block_started_at,'+9 hours')||'+09:00' AS block_started_jst, CASE WHEN block_ended_at IS NOT NULL THEN datetime(block_ended_at,'+9 hours')||'+09:00' END AS block_ended_jst, tokens_used, usage_ratio FROM snapshots ORDER BY taken_at DESC LIMIT 10;"
+	sqlite3 $(DB_PATH) "SELECT datetime(taken_at,'+9 hours')||'+09:00' AS taken_at_jst, tokens_used, usage_ratio, weekly_tokens, weekly_sonnet_tokens FROM snapshots ORDER BY taken_at DESC LIMIT 10;"

--- a/cmd/current/main.go
+++ b/cmd/current/main.go
@@ -13,16 +13,25 @@ import (
 var jst = time.FixedZone("JST", 9*60*60)
 
 type jsonOutput struct {
-	TokensUsed    int     `json:"tokens_used"`
-	PlanLimit     int     `json:"plan_limit"`
-	UsageRatio    float64 `json:"usage_ratio"`
-	BlockStartsAt string  `json:"block_starts_at,omitempty"`
-	BlockEndsAt   string  `json:"block_ends_at,omitempty"`
+	Session struct {
+		TokensUsed int     `json:"tokens_used"`
+		Limit      int     `json:"limit,omitempty"`
+		Ratio      float64 `json:"ratio,omitempty"`
+		EndsAt     string  `json:"ends_at,omitempty"`
+	} `json:"session"`
+	Weekly struct {
+		TokensUsed    int     `json:"tokens_used"`
+		Limit         int     `json:"limit,omitempty"`
+		Ratio         float64 `json:"ratio,omitempty"`
+		SonnetTokens  int     `json:"sonnet_tokens_used"`
+		SonnetLimit   int     `json:"sonnet_limit,omitempty"`
+		SonnetRatio   float64 `json:"sonnet_ratio,omitempty"`
+		ResetsAt      string  `json:"resets_at"`
+	} `json:"weekly"`
 }
 
 func main() {
 	logger := slog.New(slog.NewJSONHandler(os.Stderr, nil))
-
 	jsonFlag := len(os.Args) > 1 && os.Args[1] == "--json"
 
 	cfg := service.ConfigFromEnv()
@@ -33,15 +42,21 @@ func main() {
 	}
 
 	if jsonFlag {
-		out := jsonOutput{
-			TokensUsed: result.TokensUsed,
-			PlanLimit:  result.PlanLimit,
-			UsageRatio: result.UsageRatio,
+		out := jsonOutput{}
+		out.Session.TokensUsed = result.SessionTokens
+		out.Session.Limit = result.SessionLimit
+		out.Session.Ratio = result.SessionRatio
+		if result.SessionEndsAt != nil {
+			out.Session.EndsAt = result.SessionEndsAt.In(jst).Format("2006-01-02T15:04:05+09:00")
 		}
-		if result.ActiveBlock != nil {
-			out.BlockStartsAt = result.ActiveBlock.StartTime.In(jst).Format("2006-01-02T15:04:05+09:00")
-			out.BlockEndsAt = result.ActiveBlock.EndTime.In(jst).Format("2006-01-02T15:04:05+09:00")
-		}
+		out.Weekly.TokensUsed = result.WeeklyTokens
+		out.Weekly.Limit = result.WeeklyLimit
+		out.Weekly.Ratio = result.WeeklyRatio
+		out.Weekly.SonnetTokens = result.WeeklySonnetTokens
+		out.Weekly.SonnetLimit = result.WeeklySonnetLimit
+		out.Weekly.SonnetRatio = result.WeeklySonnetRatio
+		out.Weekly.ResetsAt = result.WeeklyResetsAt.In(jst).Format("2006-01-02T15:04:05+09:00")
+
 		enc := json.NewEncoder(os.Stdout)
 		enc.SetIndent("", "  ")
 		if err := enc.Encode(out); err != nil {
@@ -51,15 +66,37 @@ func main() {
 		return
 	}
 
-	pct := result.UsageRatio * 100
-	usedM := float64(result.TokensUsed) / 1_000_000
-	limitM := float64(result.PlanLimit) / 1_000_000
+	// Human-readable: match /usage format
+	resetsAt := result.WeeklyResetsAt.In(jst).Format("Jan 2, 3pm")
 
-	if result.ActiveBlock == nil {
-		fmt.Printf("%.1f%% (tokens: %.0fM / %.0fM, no active block)\n", pct, usedM, limitM)
-		return
+	fmt.Printf("Current session   %s\n", sessionLine(result))
+	fmt.Printf("Weekly (All)      %s\n", weeklyLine(result.WeeklyTokens, result.WeeklyLimit, result.WeeklyRatio, resetsAt))
+	fmt.Printf("Weekly (Sonnet)   %s\n", weeklyLine(result.WeeklySonnetTokens, result.WeeklySonnetLimit, result.WeeklySonnetRatio, resetsAt))
+}
+
+func sessionLine(r *service.UsageResult) string {
+	endsAt := ""
+	if r.SessionEndsAt != nil {
+		endsAt = ", resets " + r.SessionEndsAt.In(jst).Format("3pm (Asia/Tokyo)")
 	}
+	if r.SessionLimit > 0 {
+		pct := r.SessionRatio * 100
+		return fmt.Sprintf("%.0f%% used (%s / %s%s)", pct, formatM(r.SessionTokens), formatM(r.SessionLimit), endsAt)
+	}
+	return fmt.Sprintf("%s used%s", formatM(r.SessionTokens), endsAt)
+}
 
-	blockEnds := result.ActiveBlock.EndTime.In(jst).Format("2006-01-02T15:04:05+09:00")
-	fmt.Printf("%.1f%% (tokens: %.0fM / %.0fM, block ends at %s)\n", pct, usedM, limitM, blockEnds)
+func weeklyLine(tokens, limit int, ratio float64, resetsAt string) string {
+	if limit > 0 {
+		return fmt.Sprintf("%.0f%% used (%s / %s, resets %s (Asia/Tokyo))", ratio*100, formatM(tokens), formatM(limit), resetsAt)
+	}
+	return fmt.Sprintf("%s used (resets %s (Asia/Tokyo))", formatM(tokens), resetsAt)
+}
+
+func formatM(n int) string {
+	m := float64(n) / 1_000_000
+	if m < 1 {
+		return fmt.Sprintf("%.0fk", float64(n)/1_000)
+	}
+	return fmt.Sprintf("%.0fM", m)
 }

--- a/cmd/current/main.go
+++ b/cmd/current/main.go
@@ -5,9 +5,12 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"time"
 
 	"github.com/rengotaku/claude-usage-tracker/internal/service"
 )
+
+var jst = time.FixedZone("JST", 9*60*60)
 
 type jsonOutput struct {
 	TokensUsed    int     `json:"tokens_used"`
@@ -36,8 +39,8 @@ func main() {
 			UsageRatio: result.UsageRatio,
 		}
 		if result.ActiveBlock != nil {
-			out.BlockStartsAt = result.ActiveBlock.StartTime.Format("2006-01-02T15:04:05Z")
-			out.BlockEndsAt = result.ActiveBlock.EndTime.Format("2006-01-02T15:04:05Z")
+			out.BlockStartsAt = result.ActiveBlock.StartTime.In(jst).Format("2006-01-02T15:04:05+09:00")
+			out.BlockEndsAt = result.ActiveBlock.EndTime.In(jst).Format("2006-01-02T15:04:05+09:00")
 		}
 		enc := json.NewEncoder(os.Stdout)
 		enc.SetIndent("", "  ")
@@ -57,6 +60,6 @@ func main() {
 		return
 	}
 
-	blockEnds := result.ActiveBlock.EndTime.Format("2006-01-02T15:04:05Z")
+	blockEnds := result.ActiveBlock.EndTime.In(jst).Format("2006-01-02T15:04:05+09:00")
 	fmt.Printf("%.1f%% (tokens: %.0fM / %.0fM, block ends at %s)\n", pct, usedM, limitM, blockEnds)
 }

--- a/cmd/snapshot/main.go
+++ b/cmd/snapshot/main.go
@@ -30,8 +30,8 @@ func main() {
 
 	snap := repository.Snapshot{
 		TakenAt:    time.Now().UTC(),
-		TokensUsed: result.TokensUsed,
-		UsageRatio: result.UsageRatio,
+		TokensUsed: result.SessionTokens,
+		UsageRatio: result.SessionRatio,
 	}
 	if result.ActiveBlock != nil {
 		snap.BlockStartedAt = result.ActiveBlock.StartTime
@@ -47,8 +47,8 @@ func main() {
 	}
 
 	logger.Info("snapshot saved",
-		"tokens_used", result.TokensUsed,
-		"plan_limit", result.PlanLimit,
-		"usage_ratio", result.UsageRatio,
+		"session_tokens", result.SessionTokens,
+		"session_ratio", result.SessionRatio,
+		"weekly_tokens", result.WeeklyTokens,
 	)
 }

--- a/cmd/snapshot/main.go
+++ b/cmd/snapshot/main.go
@@ -29,9 +29,11 @@ func main() {
 	defer repo.Close()
 
 	snap := repository.Snapshot{
-		TakenAt:    time.Now().UTC(),
-		TokensUsed: result.SessionTokens,
-		UsageRatio: result.SessionRatio,
+		TakenAt:            time.Now().UTC(),
+		TokensUsed:         result.SessionTokens,
+		UsageRatio:         result.SessionRatio,
+		WeeklyTokens:       result.WeeklyTokens,
+		WeeklySonnetTokens: result.WeeklySonnetTokens,
 	}
 	if result.ActiveBlock != nil {
 		snap.BlockStartedAt = result.ActiveBlock.StartTime

--- a/internal/repository/snapshot.go
+++ b/internal/repository/snapshot.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"time"
 
 	_ "modernc.org/sqlite"
@@ -16,11 +17,13 @@ const timeLayout = time.RFC3339
 
 // Snapshot represents a point-in-time record of token usage within a block.
 type Snapshot struct {
-	TakenAt        time.Time
-	BlockStartedAt time.Time
-	BlockEndedAt   *time.Time
-	TokensUsed     int
-	UsageRatio     float64
+	TakenAt            time.Time
+	BlockStartedAt     time.Time
+	BlockEndedAt       *time.Time
+	TokensUsed         int
+	UsageRatio         float64
+	WeeklyTokens       int
+	WeeklySonnetTokens int
 }
 
 // SnapshotRepository persists Snapshot records to SQLite.
@@ -66,21 +69,34 @@ func NewSnapshotRepository(ctx context.Context, dbPath string) (*SnapshotReposit
 func (r *SnapshotRepository) migrate(ctx context.Context) error {
 	_, err := r.db.ExecContext(ctx, `
 		CREATE TABLE IF NOT EXISTS snapshots (
-			taken_at         TEXT PRIMARY KEY,
-			block_started_at TEXT NOT NULL,
-			block_ended_at   TEXT,
-			tokens_used      INTEGER NOT NULL,
-			usage_ratio      REAL    NOT NULL
+			taken_at              TEXT PRIMARY KEY,
+			block_started_at      TEXT NOT NULL,
+			block_ended_at        TEXT,
+			tokens_used           INTEGER NOT NULL,
+			usage_ratio           REAL    NOT NULL,
+			weekly_tokens         INTEGER NOT NULL DEFAULT 0,
+			weekly_sonnet_tokens  INTEGER NOT NULL DEFAULT 0
 		)
 	`)
 	if err != nil {
 		return fmt.Errorf("create table: %w", err)
 	}
+
+	// Add weekly columns to existing tables (idempotent).
+	for _, col := range []string{
+		"ALTER TABLE snapshots ADD COLUMN weekly_tokens        INTEGER NOT NULL DEFAULT 0",
+		"ALTER TABLE snapshots ADD COLUMN weekly_sonnet_tokens INTEGER NOT NULL DEFAULT 0",
+	} {
+		if _, err := r.db.ExecContext(ctx, col); err != nil {
+			if !strings.Contains(err.Error(), "duplicate column name") {
+				return fmt.Errorf("alter table: %w", err)
+			}
+		}
+	}
 	return nil
 }
 
 // Save inserts or replaces a Snapshot (upsert by taken_at).
-// Times are truncated to second precision before persisting.
 func (r *SnapshotRepository) Save(ctx context.Context, s Snapshot) error {
 	var endedAt *string
 	if s.BlockEndedAt != nil {
@@ -89,13 +105,15 @@ func (r *SnapshotRepository) Save(ctx context.Context, s Snapshot) error {
 	}
 	_, err := r.db.ExecContext(ctx,
 		`INSERT OR REPLACE INTO snapshots
-			(taken_at, block_started_at, block_ended_at, tokens_used, usage_ratio)
-		 VALUES (?, ?, ?, ?, ?)`,
+			(taken_at, block_started_at, block_ended_at, tokens_used, usage_ratio, weekly_tokens, weekly_sonnet_tokens)
+		 VALUES (?, ?, ?, ?, ?, ?, ?)`,
 		s.TakenAt.UTC().Truncate(time.Second).Format(timeLayout),
 		s.BlockStartedAt.UTC().Truncate(time.Second).Format(timeLayout),
 		endedAt,
 		s.TokensUsed,
 		s.UsageRatio,
+		s.WeeklyTokens,
+		s.WeeklySonnetTokens,
 	)
 	if err != nil {
 		return fmt.Errorf("save snapshot: %w", err)
@@ -106,7 +124,7 @@ func (r *SnapshotRepository) Save(ctx context.Context, s Snapshot) error {
 // Latest returns the most recently taken Snapshot, or nil if none exists.
 func (r *SnapshotRepository) Latest(ctx context.Context) (*Snapshot, error) {
 	row := r.db.QueryRowContext(ctx,
-		`SELECT taken_at, block_started_at, block_ended_at, tokens_used, usage_ratio
+		`SELECT taken_at, block_started_at, block_ended_at, tokens_used, usage_ratio, weekly_tokens, weekly_sonnet_tokens
 		 FROM snapshots ORDER BY taken_at DESC LIMIT 1`)
 	s, err := scanRow(row)
 	if errors.Is(err, sql.ErrNoRows) {
@@ -118,7 +136,7 @@ func (r *SnapshotRepository) Latest(ctx context.Context) (*Snapshot, error) {
 // ListBetween returns Snapshots with taken_at in [from, to], ordered ascending.
 func (r *SnapshotRepository) ListBetween(ctx context.Context, from, to time.Time) ([]Snapshot, error) {
 	rows, err := r.db.QueryContext(ctx,
-		`SELECT taken_at, block_started_at, block_ended_at, tokens_used, usage_ratio
+		`SELECT taken_at, block_started_at, block_ended_at, tokens_used, usage_ratio, weekly_tokens, weekly_sonnet_tokens
 		 FROM snapshots
 		 WHERE taken_at >= ? AND taken_at <= ?
 		 ORDER BY taken_at`,
@@ -160,13 +178,15 @@ func scanRows(s *sql.Rows) (*Snapshot, error) {
 
 func scan(s scanner) (*Snapshot, error) {
 	var (
-		takenAt        string
-		blockStartedAt string
-		blockEndedAt   *string
-		tokensUsed     int
-		usageRatio     float64
+		takenAt            string
+		blockStartedAt     string
+		blockEndedAt       *string
+		tokensUsed         int
+		usageRatio         float64
+		weeklyTokens       int
+		weeklySonnetTokens int
 	)
-	if err := s.Scan(&takenAt, &blockStartedAt, &blockEndedAt, &tokensUsed, &usageRatio); err != nil {
+	if err := s.Scan(&takenAt, &blockStartedAt, &blockEndedAt, &tokensUsed, &usageRatio, &weeklyTokens, &weeklySonnetTokens); err != nil {
 		return nil, err
 	}
 
@@ -180,10 +200,12 @@ func scan(s scanner) (*Snapshot, error) {
 	}
 
 	snap := &Snapshot{
-		TakenAt:        ta.UTC(),
-		BlockStartedAt: bs.UTC(),
-		TokensUsed:     tokensUsed,
-		UsageRatio:     usageRatio,
+		TakenAt:            ta.UTC(),
+		BlockStartedAt:     bs.UTC(),
+		TokensUsed:         tokensUsed,
+		UsageRatio:         usageRatio,
+		WeeklyTokens:       weeklyTokens,
+		WeeklySonnetTokens: weeklySonnetTokens,
 	}
 	if blockEndedAt != nil {
 		be, err := time.Parse(timeLayout, *blockEndedAt)

--- a/internal/service/usage.go
+++ b/internal/service/usage.go
@@ -4,52 +4,68 @@ import (
 	"fmt"
 	"os"
 	"strconv"
+	"strings"
+	"time"
 
 	"github.com/rengotaku/claude-usage-tracker/internal/blocks"
 	"github.com/rengotaku/claude-usage-tracker/internal/jsonl"
 )
 
-const defaultPlanLimit = 200_000_000
+var jst = time.FixedZone("JST", 9*60*60)
 
 // Config holds runtime configuration for usage computation.
 type Config struct {
-	LogDir    string
-	PlanLimit int
+	LogDir              string
+	SessionLimit        int // 5-hour block limit (0 = unknown)
+	WeeklyLimit         int // weekly all-models limit (0 = unknown)
+	WeeklySonnetLimit   int // weekly Sonnet-only limit (0 = unknown)
 }
 
-// ConfigFromEnv builds Config from environment variables with defaults.
+// ConfigFromEnv builds Config from environment variables.
 func ConfigFromEnv() Config {
 	logDir := os.Getenv("CLAUDE_USAGE_TRACKER_LOG_DIR")
 	if logDir == "" {
 		home, _ := os.UserHomeDir()
 		logDir = home + "/.claude/projects"
 	}
+	return Config{
+		LogDir:            logDir,
+		SessionLimit:      envInt("CLAUDE_USAGE_TRACKER_PLAN_LIMIT", 0),
+		WeeklyLimit:       envInt("CLAUDE_USAGE_TRACKER_WEEKLY_LIMIT", 0),
+		WeeklySonnetLimit: envInt("CLAUDE_USAGE_TRACKER_WEEKLY_SONNET_LIMIT", 0),
+	}
+}
 
-	planLimit := defaultPlanLimit
-	if v := os.Getenv("CLAUDE_USAGE_TRACKER_PLAN_LIMIT"); v != "" {
+func envInt(key string, def int) int {
+	if v := os.Getenv(key); v != "" {
 		if n, err := strconv.Atoi(v); err == nil && n > 0 {
-			planLimit = n
+			return n
 		}
 	}
-
-	return Config{LogDir: logDir, PlanLimit: planLimit}
+	return def
 }
 
-// UsageResult is the computed usage for the current billing block.
+// UsageResult holds session and weekly usage metrics.
 type UsageResult struct {
-	TokensUsed  int
-	PlanLimit   int
-	UsageRatio  float64
-	ActiveBlock *blocks.Block
+	// Current 5-hour session block
+	SessionTokens int
+	SessionLimit  int
+	SessionRatio  float64 // 0 if limit unknown
+	SessionEndsAt *time.Time
+	ActiveBlock   *blocks.Block
+
+	// Weekly (since last Friday 08:00 JST)
+	WeeklyTokens       int
+	WeeklyLimit        int
+	WeeklyRatio        float64 // 0 if limit unknown
+	WeeklySonnetTokens int
+	WeeklySonnetLimit  int
+	WeeklySonnetRatio  float64 // 0 if limit unknown
+	WeeklyResetsAt     time.Time
 }
 
-// Compute parses JSONL logs and returns current block usage.
-// If no active block exists, TokensUsed and UsageRatio are zero.
+// Compute parses JSONL logs and returns session + weekly usage.
 func Compute(cfg Config) (*UsageResult, error) {
-	if cfg.PlanLimit <= 0 {
-		return nil, fmt.Errorf("plan_limit must be positive")
-	}
-
 	entries, err := jsonl.Parse(cfg.LogDir)
 	if err != nil {
 		return nil, fmt.Errorf("parse logs: %w", err)
@@ -58,11 +74,66 @@ func Compute(cfg Config) (*UsageResult, error) {
 	bs := blocks.Build(entries)
 	active := blocks.ActiveBlock(bs)
 
-	result := &UsageResult{PlanLimit: cfg.PlanLimit}
-	if active != nil {
-		result.TokensUsed = active.TotalTokens
-		result.UsageRatio = float64(active.TotalTokens) / float64(cfg.PlanLimit)
-		result.ActiveBlock = active
+	result := &UsageResult{
+		SessionLimit:      cfg.SessionLimit,
+		WeeklyLimit:       cfg.WeeklyLimit,
+		WeeklySonnetLimit: cfg.WeeklySonnetLimit,
+		WeeklyResetsAt:    nextWeeklyReset(),
 	}
+
+	if active != nil {
+		result.SessionTokens = active.TotalTokens
+		result.ActiveBlock = active
+		end := active.EndTime
+		result.SessionEndsAt = &end
+		if cfg.SessionLimit > 0 {
+			result.SessionRatio = float64(active.TotalTokens) / float64(cfg.SessionLimit)
+		}
+	}
+
+	weekStart := lastWeeklyReset()
+	for _, e := range entries {
+		if e.Timestamp.Before(weekStart) {
+			continue
+		}
+		t := totalTokens(e)
+		result.WeeklyTokens += t
+		if isSonnet(e.Model) {
+			result.WeeklySonnetTokens += t
+		}
+	}
+	if cfg.WeeklyLimit > 0 {
+		result.WeeklyRatio = float64(result.WeeklyTokens) / float64(cfg.WeeklyLimit)
+	}
+	if cfg.WeeklySonnetLimit > 0 {
+		result.WeeklySonnetRatio = float64(result.WeeklySonnetTokens) / float64(cfg.WeeklySonnetLimit)
+	}
+
 	return result, nil
+}
+
+// lastWeeklyReset returns the most recent Friday 08:00 JST.
+func lastWeeklyReset() time.Time {
+	now := time.Now().In(jst)
+	// weekday: Monday=1 ... Friday=5 ... Sunday=0
+	daysSinceFriday := (int(now.Weekday()) - int(time.Friday) + 7) % 7
+	reset := time.Date(now.Year(), now.Month(), now.Day()-daysSinceFriday, 8, 0, 0, 0, jst)
+	if now.Before(reset) {
+		reset = reset.AddDate(0, 0, -7)
+	}
+	return reset
+}
+
+// nextWeeklyReset returns the next Friday 08:00 JST.
+func nextWeeklyReset() time.Time {
+	last := lastWeeklyReset()
+	return last.AddDate(0, 0, 7)
+}
+
+func totalTokens(e jsonl.UsageEntry) int {
+	return e.InputTokens + e.OutputTokens + e.CacheCreationInputTokens + e.CacheReadInputTokens
+}
+
+func isSonnet(model string) bool {
+	return strings.Contains(strings.ToLower(model), "sonnet")
 }

--- a/internal/service/usage_test.go
+++ b/internal/service/usage_test.go
@@ -11,17 +11,17 @@ import (
 
 func TestCompute_NoEntries(t *testing.T) {
 	dir := t.TempDir()
-	cfg := service.Config{LogDir: dir, PlanLimit: 1_000_000}
+	cfg := service.Config{LogDir: dir, SessionLimit: 1_000_000}
 
 	result, err := service.Compute(cfg)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if result.TokensUsed != 0 {
-		t.Errorf("expected 0 tokens, got %d", result.TokensUsed)
+	if result.SessionTokens != 0 {
+		t.Errorf("expected 0 session tokens, got %d", result.SessionTokens)
 	}
-	if result.UsageRatio != 0 {
-		t.Errorf("expected 0 ratio, got %f", result.UsageRatio)
+	if result.SessionRatio != 0 {
+		t.Errorf("expected 0 ratio, got %f", result.SessionRatio)
 	}
 	if result.ActiveBlock != nil {
 		t.Error("expected no active block")
@@ -33,7 +33,7 @@ func TestCompute_ActiveBlock(t *testing.T) {
 	now := time.Now().UTC()
 	writeJSONL(t, dir, now)
 
-	cfg := service.Config{LogDir: dir, PlanLimit: 1_000_000}
+	cfg := service.Config{LogDir: dir, SessionLimit: 1_000_000}
 	result, err := service.Compute(cfg)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -43,20 +43,52 @@ func TestCompute_ActiveBlock(t *testing.T) {
 		t.Fatal("expected active block")
 	}
 	// input(100) + output(200) = 300
-	if result.TokensUsed != 300 {
-		t.Errorf("expected 300 tokens, got %d", result.TokensUsed)
+	if result.SessionTokens != 300 {
+		t.Errorf("expected 300 session tokens, got %d", result.SessionTokens)
 	}
 	want := float64(300) / float64(1_000_000)
-	if result.UsageRatio != want {
-		t.Errorf("expected ratio %f, got %f", want, result.UsageRatio)
+	if result.SessionRatio != want {
+		t.Errorf("expected ratio %f, got %f", want, result.SessionRatio)
 	}
 }
 
-func TestCompute_InvalidPlanLimit(t *testing.T) {
-	cfg := service.Config{LogDir: t.TempDir(), PlanLimit: 0}
-	_, err := service.Compute(cfg)
-	if err == nil {
-		t.Error("expected error for zero plan_limit")
+func TestCompute_WeeklyTokens(t *testing.T) {
+	dir := t.TempDir()
+	now := time.Now().UTC()
+	writeJSONL(t, dir, now)
+
+	cfg := service.Config{LogDir: dir}
+	result, err := service.Compute(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// 300 tokens total, all Sonnet
+	if result.WeeklyTokens != 300 {
+		t.Errorf("expected 300 weekly tokens, got %d", result.WeeklyTokens)
+	}
+	if result.WeeklySonnetTokens != 300 {
+		t.Errorf("expected 300 weekly sonnet tokens, got %d", result.WeeklySonnetTokens)
+	}
+}
+
+func TestCompute_WeeklyLimit(t *testing.T) {
+	dir := t.TempDir()
+	writeJSONL(t, dir, time.Now().UTC())
+
+	cfg := service.Config{LogDir: dir, WeeklyLimit: 1_000_000, WeeklySonnetLimit: 500_000}
+	result, err := service.Compute(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	wantWeekly := float64(300) / float64(1_000_000)
+	if result.WeeklyRatio != wantWeekly {
+		t.Errorf("expected weekly ratio %f, got %f", wantWeekly, result.WeeklyRatio)
+	}
+	wantSonnet := float64(300) / float64(500_000)
+	if result.WeeklySonnetRatio != wantSonnet {
+		t.Errorf("expected sonnet ratio %f, got %f", wantSonnet, result.WeeklySonnetRatio)
 	}
 }
 
@@ -65,8 +97,8 @@ func TestConfigFromEnv_Defaults(t *testing.T) {
 	t.Setenv("CLAUDE_USAGE_TRACKER_PLAN_LIMIT", "")
 
 	cfg := service.ConfigFromEnv()
-	if cfg.PlanLimit != 200_000_000 {
-		t.Errorf("expected default plan limit 200_000_000, got %d", cfg.PlanLimit)
+	if cfg.SessionLimit != 0 {
+		t.Errorf("expected default session limit 0, got %d", cfg.SessionLimit)
 	}
 	if cfg.LogDir == "" {
 		t.Error("expected non-empty log dir")
@@ -75,14 +107,22 @@ func TestConfigFromEnv_Defaults(t *testing.T) {
 
 func TestConfigFromEnv_EnvOverride(t *testing.T) {
 	t.Setenv("CLAUDE_USAGE_TRACKER_LOG_DIR", "/tmp/logs")
-	t.Setenv("CLAUDE_USAGE_TRACKER_PLAN_LIMIT", "500000")
+	t.Setenv("CLAUDE_USAGE_TRACKER_PLAN_LIMIT", "53000000")
+	t.Setenv("CLAUDE_USAGE_TRACKER_WEEKLY_LIMIT", "1000000000")
+	t.Setenv("CLAUDE_USAGE_TRACKER_WEEKLY_SONNET_LIMIT", "500000000")
 
 	cfg := service.ConfigFromEnv()
 	if cfg.LogDir != "/tmp/logs" {
 		t.Errorf("expected /tmp/logs, got %s", cfg.LogDir)
 	}
-	if cfg.PlanLimit != 500_000 {
-		t.Errorf("expected 500000, got %d", cfg.PlanLimit)
+	if cfg.SessionLimit != 53_000_000 {
+		t.Errorf("expected 53000000, got %d", cfg.SessionLimit)
+	}
+	if cfg.WeeklyLimit != 1_000_000_000 {
+		t.Errorf("expected 1000000000, got %d", cfg.WeeklyLimit)
+	}
+	if cfg.WeeklySonnetLimit != 500_000_000 {
+		t.Errorf("expected 500000000, got %d", cfg.WeeklySonnetLimit)
 	}
 }
 


### PR DESCRIPTION
## 概要

Issue #1 のフィードバック対応（JST表示・週次使用量追跡）。

- **JST統一**: `cmd/current` の時刻表示を `+09:00` 形式に変更
- **Weekly表示追加**: `/usage` コマンドと同じ3項目（Current session / Weekly All / Weekly Sonnet）を表示
- **SQLite週次保存**: `weekly_tokens` / `weekly_sonnet_tokens` カラムを追加し snapshot ごとに記録
- **make db 更新**: 週次カラムを含む JST 表示クエリに変更

## 動作確認

```
$ claude-usage-tracker-current
Current session   22M used, resets 10am (Asia/Tokyo)
Weekly (All)      340M used (resets Apr 24, 8am (Asia/Tokyo))
Weekly (Sonnet)   114M used (resets Apr 24, 8am (Asia/Tokyo))

$ make db
2026-04-21 08:54:32+09:00 | tokens_used=25580442 | weekly=343793414 | weekly_sonnet=118110736
```

## 環境変数（% 表示に切り替え）

```bash
CLAUDE_USAGE_TRACKER_PLAN_LIMIT=61000000
CLAUDE_USAGE_TRACKER_WEEKLY_LIMIT=810000000
CLAUDE_USAGE_TRACKER_WEEKLY_SONNET_LIMIT=713000000
```

既存 DB は `ALTER TABLE ADD COLUMN` で自動マイグレーション済み。
