### PR TITLE
HTTP API: 時間ごとの使用量を期間指定で取得

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,8 @@
 # Binaries
 /claude-usage-tracker
+/current
+/snapshot
+/run
 *.exe
 
 # Database files

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,10 @@
-.PHONY: build test lint clean install uninstall status db
+.PHONY: build test lint clean install uninstall status db server
 
 build:
 	CGO_ENABLED=0 go build ./...
+
+server:
+	CGO_ENABLED=0 go run ./cmd/server
 
 test:
 	CGO_ENABLED=0 go test ./...

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+	"os"
+	"strconv"
+	"time"
+
+	"github.com/rengotaku/claude-usage-tracker/internal/repository"
+	"github.com/rengotaku/claude-usage-tracker/internal/server"
+)
+
+const (
+	defaultPort = "8080"
+	envPort     = "CLAUDE_USAGE_TRACKER_PORT"
+)
+
+func main() {
+	logger := slog.New(slog.NewJSONHandler(os.Stderr, nil))
+
+	port := os.Getenv(envPort)
+	if port == "" {
+		port = defaultPort
+	}
+
+	dbPath := repository.DBPath()
+	repo, err := repository.NewSnapshotRepository(context.Background(), dbPath)
+	if err != nil {
+		logger.Error("open repository", "path", dbPath, "error", err)
+		os.Exit(1)
+	}
+	defer repo.Close()
+
+	cfg := server.Config{
+		SessionLimit:      envInt("CLAUDE_USAGE_TRACKER_PLAN_LIMIT"),
+		WeeklyLimit:       envInt("CLAUDE_USAGE_TRACKER_WEEKLY_LIMIT"),
+		WeeklySonnetLimit: envInt("CLAUDE_USAGE_TRACKER_WEEKLY_SONNET_LIMIT"),
+	}
+	h := server.NewHandler(repo, cfg)
+
+	srv := &http.Server{
+		Addr:              ":" + port,
+		Handler:           h.Routes(),
+		ReadHeaderTimeout: 5 * time.Second,
+	}
+
+	logger.Info("server listening", "addr", srv.Addr, "db", dbPath)
+	if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+		logger.Error("serve", "error", err)
+		os.Exit(1)
+	}
+}
+
+func envInt(key string) int {
+	if v := os.Getenv(key); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			return n
+		}
+	}
+	return 0
+}

--- a/internal/server/aggregation.go
+++ b/internal/server/aggregation.go
@@ -1,0 +1,96 @@
+package server
+
+import (
+	"sort"
+	"time"
+
+	"github.com/rengotaku/claude-usage-tracker/internal/repository"
+)
+
+var jst = time.FixedZone("JST", 9*60*60)
+
+// BlockAgg represents a 5-hour block aggregation derived from snapshots.
+type BlockAgg struct {
+	Start  time.Time
+	End    *time.Time
+	Tokens int
+	Ratio  float64
+}
+
+// DailyAgg represents one-day aggregation of session tokens.
+type DailyAgg struct {
+	Date   string // YYYY-MM-DD in JST
+	Tokens int    // sum of block totals for that day
+	Blocks int    // number of distinct 5h blocks
+}
+
+// AggregateBlocks groups snapshots by block_started_at and returns the
+// block totals. Each block's Tokens is the MAX(tokens_used) within that
+// group (since tokens_used is cumulative within an active block).
+// Snapshots without a BlockEndedAt represent no-active-block placeholders
+// (see cmd/snapshot) and are skipped.
+func AggregateBlocks(snaps []repository.Snapshot) []BlockAgg {
+	if len(snaps) == 0 {
+		return nil
+	}
+	type key struct{ start int64 }
+	byBlock := make(map[key]*BlockAgg)
+	for _, s := range snaps {
+		if s.BlockEndedAt == nil {
+			continue
+		}
+		k := key{s.BlockStartedAt.Unix()}
+		agg, ok := byBlock[k]
+		if !ok {
+			agg = &BlockAgg{Start: s.BlockStartedAt, End: s.BlockEndedAt}
+			byBlock[k] = agg
+		}
+		if s.TokensUsed > agg.Tokens {
+			agg.Tokens = s.TokensUsed
+			agg.Ratio = s.UsageRatio
+		}
+	}
+	result := make([]BlockAgg, 0, len(byBlock))
+	for _, v := range byBlock {
+		result = append(result, *v)
+	}
+	sort.Slice(result, func(i, j int) bool { return result[i].Start.Before(result[j].Start) })
+	return result
+}
+
+// AggregateDaily groups block aggregations into days by JST date.
+func AggregateDaily(blocks []BlockAgg) []DailyAgg {
+	if len(blocks) == 0 {
+		return nil
+	}
+	byDate := make(map[string]*DailyAgg)
+	for _, b := range blocks {
+		d := b.Start.In(jst).Format("2006-01-02")
+		agg, ok := byDate[d]
+		if !ok {
+			agg = &DailyAgg{Date: d}
+			byDate[d] = agg
+		}
+		agg.Tokens += b.Tokens
+		agg.Blocks++
+	}
+	result := make([]DailyAgg, 0, len(byDate))
+	for _, v := range byDate {
+		result = append(result, *v)
+	}
+	sort.Slice(result, func(i, j int) bool { return result[i].Date < result[j].Date })
+	return result
+}
+
+// SumWeeklyTokens returns the latest weekly_tokens value observed in snaps
+// (the tracker stores a running weekly counter; the max/last value represents
+// the current weekly total for the range).
+func SumWeeklyTokens(snaps []repository.Snapshot) int {
+	var max int
+	for _, s := range snaps {
+		if s.WeeklyTokens > max {
+			max = s.WeeklyTokens
+		}
+	}
+	return max
+}

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -1,0 +1,307 @@
+package server
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/rengotaku/claude-usage-tracker/internal/repository"
+)
+
+// timeFormat for JSON output (JST).
+const jsonTimeFormat = "2006-01-02T15:04:05-07:00"
+
+type errorResponse struct {
+	Error string `json:"error"`
+}
+
+// parseRange parses from/to query params. Supports RFC3339 or YYYY-MM-DD.
+// If either is missing, applies the provided default window ending at now.
+func parseRange(r *http.Request, defaultWindow time.Duration) (time.Time, time.Time, error) {
+	now := time.Now().UTC()
+	to := now
+	from := now.Add(-defaultWindow)
+
+	if v := r.URL.Query().Get("from"); v != "" {
+		t, err := parseFlexibleTime(v, false)
+		if err != nil {
+			return time.Time{}, time.Time{}, fmt.Errorf("invalid from: %w", err)
+		}
+		from = t
+	}
+	if v := r.URL.Query().Get("to"); v != "" {
+		t, err := parseFlexibleTime(v, true)
+		if err != nil {
+			return time.Time{}, time.Time{}, fmt.Errorf("invalid to: %w", err)
+		}
+		to = t
+	}
+	if to.Before(from) {
+		return time.Time{}, time.Time{}, fmt.Errorf("to must be >= from")
+	}
+	return from, to, nil
+}
+
+// parseFlexibleTime parses RFC3339 or YYYY-MM-DD. For date-only, endOfDay
+// controls whether the time is 00:00:00 or 23:59:59 (JST-anchored).
+func parseFlexibleTime(v string, endOfDay bool) (time.Time, error) {
+	if t, err := time.Parse(time.RFC3339, v); err == nil {
+		return t.UTC(), nil
+	}
+	if t, err := time.ParseInLocation("2006-01-02", v, jst); err == nil {
+		if endOfDay {
+			t = t.Add(24*time.Hour - time.Second)
+		}
+		return t.UTC(), nil
+	}
+	return time.Time{}, fmt.Errorf("must be RFC3339 or YYYY-MM-DD, got %q", v)
+}
+
+func writeJSON(w http.ResponseWriter, status int, body any) {
+	w.Header().Set("Content-Type", "application/json; charset=utf-8")
+	w.WriteHeader(status)
+	enc := json.NewEncoder(w)
+	enc.SetIndent("", "  ")
+	_ = enc.Encode(body)
+}
+
+func writeError(w http.ResponseWriter, status int, msg string) {
+	writeJSON(w, status, errorResponse{Error: msg})
+}
+
+// --- /usage/snapshots ---
+
+type snapshotItem struct {
+	TakenAt            string  `json:"taken_at"`
+	BlockStartedAt     string  `json:"block_started_at"`
+	BlockEndedAt       string  `json:"block_ended_at,omitempty"`
+	SessionTokens      int     `json:"session_tokens"`
+	SessionRatio       float64 `json:"session_ratio"`
+	WeeklyTokens       int     `json:"weekly_tokens"`
+	WeeklySonnetTokens int     `json:"weekly_sonnet_tokens"`
+}
+
+type snapshotsResponse struct {
+	Period    periodDTO      `json:"period"`
+	Snapshots []snapshotItem `json:"snapshots"`
+}
+
+type periodDTO struct {
+	From string `json:"from"`
+	To   string `json:"to"`
+}
+
+func (h *Handler) Snapshots(w http.ResponseWriter, r *http.Request) {
+	from, to, err := parseRange(r, 24*time.Hour)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	snaps, err := h.repo.ListBetween(r.Context(), from, to)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	items := make([]snapshotItem, 0, len(snaps))
+	for _, s := range snaps {
+		item := snapshotItem{
+			TakenAt:            s.TakenAt.In(jst).Format(jsonTimeFormat),
+			BlockStartedAt:     s.BlockStartedAt.In(jst).Format(jsonTimeFormat),
+			SessionTokens:      s.TokensUsed,
+			SessionRatio:       s.UsageRatio,
+			WeeklyTokens:       s.WeeklyTokens,
+			WeeklySonnetTokens: s.WeeklySonnetTokens,
+		}
+		if s.BlockEndedAt != nil {
+			item.BlockEndedAt = s.BlockEndedAt.In(jst).Format(jsonTimeFormat)
+		}
+		items = append(items, item)
+	}
+	writeJSON(w, http.StatusOK, snapshotsResponse{
+		Period:    periodDTO{From: from.In(jst).Format(jsonTimeFormat), To: to.In(jst).Format(jsonTimeFormat)},
+		Snapshots: items,
+	})
+}
+
+// --- /usage/blocks ---
+
+type blockItem struct {
+	Start  string  `json:"start"`
+	End    string  `json:"end,omitempty"`
+	Tokens int     `json:"tokens"`
+	Ratio  float64 `json:"ratio"`
+}
+
+type weeklyDTO struct {
+	TotalTokens int     `json:"total_tokens"`
+	Limit       int     `json:"limit,omitempty"`
+	Ratio       float64 `json:"ratio,omitempty"`
+}
+
+type blocksResponse struct {
+	Period periodDTO   `json:"period"`
+	Blocks []blockItem `json:"blocks"`
+	Weekly weeklyDTO   `json:"weekly"`
+}
+
+func (h *Handler) Blocks(w http.ResponseWriter, r *http.Request) {
+	from, to, err := parseRange(r, 7*24*time.Hour)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	snaps, err := h.repo.ListBetween(r.Context(), from, to)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	aggs := AggregateBlocks(snaps)
+	items := make([]blockItem, 0, len(aggs))
+	for _, b := range aggs {
+		item := blockItem{
+			Start:  b.Start.In(jst).Format(jsonTimeFormat),
+			Tokens: b.Tokens,
+			Ratio:  b.Ratio,
+		}
+		if b.End != nil {
+			item.End = b.End.In(jst).Format(jsonTimeFormat)
+		}
+		items = append(items, item)
+	}
+	weeklyTotal := SumWeeklyTokens(snaps)
+	weekly := weeklyDTO{TotalTokens: weeklyTotal, Limit: h.cfg.WeeklyLimit}
+	if h.cfg.WeeklyLimit > 0 {
+		weekly.Ratio = float64(weeklyTotal) / float64(h.cfg.WeeklyLimit)
+	}
+	writeJSON(w, http.StatusOK, blocksResponse{
+		Period: periodDTO{From: from.In(jst).Format(jsonTimeFormat), To: to.In(jst).Format(jsonTimeFormat)},
+		Blocks: items,
+		Weekly: weekly,
+	})
+}
+
+// --- /usage/daily ---
+
+type dailyItem struct {
+	Date   string `json:"date"`
+	Tokens int    `json:"tokens"`
+	Blocks int    `json:"blocks"`
+}
+
+type dailyResponse struct {
+	Period periodDTO   `json:"period"`
+	Daily  []dailyItem `json:"daily"`
+}
+
+func (h *Handler) Daily(w http.ResponseWriter, r *http.Request) {
+	from, to, err := parseRange(r, 7*24*time.Hour)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	snaps, err := h.repo.ListBetween(r.Context(), from, to)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	daily := AggregateDaily(AggregateBlocks(snaps))
+	items := make([]dailyItem, 0, len(daily))
+	for _, d := range daily {
+		items = append(items, dailyItem{Date: d.Date, Tokens: d.Tokens, Blocks: d.Blocks})
+	}
+	writeJSON(w, http.StatusOK, dailyResponse{
+		Period: periodDTO{From: from.In(jst).Format(jsonTimeFormat), To: to.In(jst).Format(jsonTimeFormat)},
+		Daily:  items,
+	})
+}
+
+// --- /usage/summary ---
+
+type summaryResponse struct {
+	Window         string    `json:"window"`
+	Current        periodSum `json:"current"`
+	Previous       periodSum `json:"previous"`
+	DeltaRatio     float64   `json:"delta_ratio"` // (current-previous)/previous, 0 if previous=0
+	WeeklySonnet   int       `json:"weekly_sonnet_tokens,omitempty"`
+}
+
+type periodSum struct {
+	From   string `json:"from"`
+	To     string `json:"to"`
+	Tokens int    `json:"tokens"`
+}
+
+func windowDuration(w string) (time.Duration, error) {
+	switch w {
+	case "", "week":
+		return 7 * 24 * time.Hour, nil
+	case "month":
+		return 30 * 24 * time.Hour, nil
+	case "6month":
+		return 180 * 24 * time.Hour, nil
+	case "year":
+		return 365 * 24 * time.Hour, nil
+	default:
+		return 0, fmt.Errorf("window must be week|month|6month|year, got %q", w)
+	}
+}
+
+func (h *Handler) Summary(w http.ResponseWriter, r *http.Request) {
+	win := r.URL.Query().Get("window")
+	if win == "" {
+		win = "week"
+	}
+	d, err := windowDuration(win)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	now := time.Now().UTC()
+	curFrom := now.Add(-d)
+	prevFrom := curFrom.Add(-d)
+
+	curSnaps, err := h.repo.ListBetween(r.Context(), curFrom, now)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	prevSnaps, err := h.repo.ListBetween(r.Context(), prevFrom, curFrom)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, err.Error())
+		return
+	}
+	curTokens := sumBlockTokens(AggregateBlocks(curSnaps))
+	prevTokens := sumBlockTokens(AggregateBlocks(prevSnaps))
+
+	var delta float64
+	if prevTokens > 0 {
+		delta = float64(curTokens-prevTokens) / float64(prevTokens)
+	}
+
+	writeJSON(w, http.StatusOK, summaryResponse{
+		Window:       win,
+		Current:      periodSum{From: curFrom.In(jst).Format(jsonTimeFormat), To: now.In(jst).Format(jsonTimeFormat), Tokens: curTokens},
+		Previous:     periodSum{From: prevFrom.In(jst).Format(jsonTimeFormat), To: curFrom.In(jst).Format(jsonTimeFormat), Tokens: prevTokens},
+		DeltaRatio:   delta,
+		WeeklySonnet: latestWeeklySonnet(curSnaps),
+	})
+}
+
+func sumBlockTokens(aggs []BlockAgg) int {
+	var sum int
+	for _, b := range aggs {
+		sum += b.Tokens
+	}
+	return sum
+}
+
+func latestWeeklySonnet(snaps []repository.Snapshot) int {
+	var max int
+	for _, s := range snaps {
+		if s.WeeklySonnetTokens > max {
+			max = s.WeeklySonnetTokens
+		}
+	}
+	return max
+}

--- a/internal/server/handlers_test.go
+++ b/internal/server/handlers_test.go
@@ -1,0 +1,288 @@
+package server_test
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/rengotaku/claude-usage-tracker/internal/repository"
+	"github.com/rengotaku/claude-usage-tracker/internal/server"
+)
+
+func newTestRepo(t *testing.T) *repository.SnapshotRepository {
+	t.Helper()
+	r, err := repository.NewSnapshotRepository(context.Background(), ":memory:")
+	if err != nil {
+		t.Fatalf("new repo: %v", err)
+	}
+	t.Cleanup(func() { r.Close() })
+	return r
+}
+
+func seedSnapshots(t *testing.T, r *repository.SnapshotRepository, snaps ...repository.Snapshot) {
+	t.Helper()
+	ctx := context.Background()
+	for _, s := range snaps {
+		if err := r.Save(ctx, s); err != nil {
+			t.Fatalf("save: %v", err)
+		}
+	}
+}
+
+func decode[T any](t *testing.T, rec *httptest.ResponseRecorder) T {
+	t.Helper()
+	var v T
+	if err := json.NewDecoder(rec.Body).Decode(&v); err != nil {
+		t.Fatalf("decode: %v (body=%s)", err, rec.Body.String())
+	}
+	return v
+}
+
+func TestSnapshotsEndpoint(t *testing.T) {
+	r := newTestRepo(t)
+	base := time.Date(2026, 4, 14, 10, 0, 0, 0, time.UTC)
+	end := base.Add(5 * time.Hour)
+	seedSnapshots(t, r,
+		repository.Snapshot{TakenAt: base, BlockStartedAt: base, BlockEndedAt: &end, TokensUsed: 1000, UsageRatio: 0.02, WeeklyTokens: 1000},
+		repository.Snapshot{TakenAt: base.Add(time.Hour), BlockStartedAt: base, BlockEndedAt: &end, TokensUsed: 5000, UsageRatio: 0.10, WeeklyTokens: 5000},
+	)
+
+	h := server.NewHandler(r, server.Config{SessionLimit: 50000, WeeklyLimit: 500000})
+	req := httptest.NewRequest(http.MethodGet, "/usage/snapshots?from=2026-04-14&to=2026-04-15", nil)
+	rec := httptest.NewRecorder()
+	h.Routes().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d, want 200 (body=%s)", rec.Code, rec.Body.String())
+	}
+	type resp struct {
+		Snapshots []struct {
+			SessionTokens int     `json:"session_tokens"`
+			SessionRatio  float64 `json:"session_ratio"`
+		} `json:"snapshots"`
+	}
+	got := decode[resp](t, rec)
+	if len(got.Snapshots) != 2 {
+		t.Fatalf("len snapshots: got %d, want 2", len(got.Snapshots))
+	}
+	if got.Snapshots[1].SessionTokens != 5000 {
+		t.Errorf("tokens[1]: got %d, want 5000", got.Snapshots[1].SessionTokens)
+	}
+}
+
+func TestSnapshotsInvalidFrom(t *testing.T) {
+	r := newTestRepo(t)
+	h := server.NewHandler(r, server.Config{})
+	req := httptest.NewRequest(http.MethodGet, "/usage/snapshots?from=not-a-date", nil)
+	rec := httptest.NewRecorder()
+	h.Routes().ServeHTTP(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status: got %d, want 400", rec.Code)
+	}
+}
+
+func TestBlocksEndpointAggregation(t *testing.T) {
+	r := newTestRepo(t)
+	// Two snapshots in block A (tokens should be MAX), one snapshot in block B.
+	blockAStart := time.Date(2026, 4, 14, 10, 0, 0, 0, time.UTC)
+	blockAEnd := blockAStart.Add(5 * time.Hour)
+	blockBStart := blockAStart.Add(6 * time.Hour)
+	blockBEnd := blockBStart.Add(5 * time.Hour)
+	seedSnapshots(t, r,
+		repository.Snapshot{TakenAt: blockAStart, BlockStartedAt: blockAStart, BlockEndedAt: &blockAEnd, TokensUsed: 2000, UsageRatio: 0.04, WeeklyTokens: 2000},
+		repository.Snapshot{TakenAt: blockAStart.Add(time.Hour), BlockStartedAt: blockAStart, BlockEndedAt: &blockAEnd, TokensUsed: 8000, UsageRatio: 0.16, WeeklyTokens: 8000},
+		repository.Snapshot{TakenAt: blockBStart, BlockStartedAt: blockBStart, BlockEndedAt: &blockBEnd, TokensUsed: 3000, UsageRatio: 0.06, WeeklyTokens: 11000},
+	)
+
+	h := server.NewHandler(r, server.Config{SessionLimit: 50000, WeeklyLimit: 500000})
+	req := httptest.NewRequest(http.MethodGet, "/usage/blocks?from=2026-04-14&to=2026-04-15", nil)
+	rec := httptest.NewRecorder()
+	h.Routes().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d, want 200 (body=%s)", rec.Code, rec.Body.String())
+	}
+	type blk struct {
+		Tokens int     `json:"tokens"`
+		Ratio  float64 `json:"ratio"`
+	}
+	type resp struct {
+		Blocks []blk `json:"blocks"`
+		Weekly struct {
+			TotalTokens int     `json:"total_tokens"`
+			Limit       int     `json:"limit"`
+			Ratio       float64 `json:"ratio"`
+		} `json:"weekly"`
+	}
+	got := decode[resp](t, rec)
+	if len(got.Blocks) != 2 {
+		t.Fatalf("len blocks: got %d, want 2", len(got.Blocks))
+	}
+	if got.Blocks[0].Tokens != 8000 {
+		t.Errorf("blocks[0].tokens (MAX): got %d, want 8000", got.Blocks[0].Tokens)
+	}
+	if got.Blocks[1].Tokens != 3000 {
+		t.Errorf("blocks[1].tokens: got %d, want 3000", got.Blocks[1].Tokens)
+	}
+	if got.Weekly.TotalTokens != 11000 {
+		t.Errorf("weekly total: got %d, want 11000", got.Weekly.TotalTokens)
+	}
+	if got.Weekly.Limit != 500000 {
+		t.Errorf("weekly limit: got %d, want 500000", got.Weekly.Limit)
+	}
+	wantRatio := float64(11000) / float64(500000)
+	if got.Weekly.Ratio < wantRatio-0.0001 || got.Weekly.Ratio > wantRatio+0.0001 {
+		t.Errorf("weekly ratio: got %f, want %f", got.Weekly.Ratio, wantRatio)
+	}
+}
+
+func TestDailyEndpoint(t *testing.T) {
+	r := newTestRepo(t)
+	// Day 1 (UTC 10:00 = JST 19:00 same day 2026-04-14): two blocks
+	d1a := time.Date(2026, 4, 14, 1, 0, 0, 0, time.UTC) // JST 10:00
+	d1aEnd := d1a.Add(5 * time.Hour)
+	d1b := time.Date(2026, 4, 14, 8, 0, 0, 0, time.UTC) // JST 17:00
+	d1bEnd := d1b.Add(5 * time.Hour)
+	// Day 2 (JST 2026-04-15)
+	d2 := time.Date(2026, 4, 15, 1, 0, 0, 0, time.UTC) // JST 10:00
+	d2End := d2.Add(5 * time.Hour)
+
+	seedSnapshots(t, r,
+		repository.Snapshot{TakenAt: d1a, BlockStartedAt: d1a, BlockEndedAt: &d1aEnd, TokensUsed: 5000, UsageRatio: 0.1},
+		repository.Snapshot{TakenAt: d1b, BlockStartedAt: d1b, BlockEndedAt: &d1bEnd, TokensUsed: 3000, UsageRatio: 0.06},
+		repository.Snapshot{TakenAt: d2, BlockStartedAt: d2, BlockEndedAt: &d2End, TokensUsed: 2000, UsageRatio: 0.04},
+	)
+
+	h := server.NewHandler(r, server.Config{})
+	req := httptest.NewRequest(http.MethodGet, "/usage/daily?from=2026-04-14&to=2026-04-16", nil)
+	rec := httptest.NewRecorder()
+	h.Routes().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d, want 200 (body=%s)", rec.Code, rec.Body.String())
+	}
+	type day struct {
+		Date   string `json:"date"`
+		Tokens int    `json:"tokens"`
+		Blocks int    `json:"blocks"`
+	}
+	type resp struct {
+		Daily []day `json:"daily"`
+	}
+	got := decode[resp](t, rec)
+	if len(got.Daily) != 2 {
+		t.Fatalf("len daily: got %d, want 2", len(got.Daily))
+	}
+	if got.Daily[0].Date != "2026-04-14" || got.Daily[0].Tokens != 8000 || got.Daily[0].Blocks != 2 {
+		t.Errorf("daily[0]: got %+v, want {2026-04-14 8000 2}", got.Daily[0])
+	}
+	if got.Daily[1].Date != "2026-04-15" || got.Daily[1].Tokens != 2000 || got.Daily[1].Blocks != 1 {
+		t.Errorf("daily[1]: got %+v, want {2026-04-15 2000 1}", got.Daily[1])
+	}
+}
+
+func TestSummaryEndpoint(t *testing.T) {
+	r := newTestRepo(t)
+	now := time.Now().UTC()
+	// current week: one block 10000 tokens
+	cur := now.Add(-24 * time.Hour)
+	curEnd := cur.Add(5 * time.Hour)
+	// previous week: one block 5000 tokens
+	prev := now.Add(-8 * 24 * time.Hour)
+	prevEnd := prev.Add(5 * time.Hour)
+
+	seedSnapshots(t, r,
+		repository.Snapshot{TakenAt: cur, BlockStartedAt: cur, BlockEndedAt: &curEnd, TokensUsed: 10000, UsageRatio: 0.2, WeeklyTokens: 10000, WeeklySonnetTokens: 4000},
+		repository.Snapshot{TakenAt: prev, BlockStartedAt: prev, BlockEndedAt: &prevEnd, TokensUsed: 5000, UsageRatio: 0.1, WeeklyTokens: 5000},
+	)
+
+	h := server.NewHandler(r, server.Config{})
+	req := httptest.NewRequest(http.MethodGet, "/usage/summary?window=week", nil)
+	rec := httptest.NewRecorder()
+	h.Routes().ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d, want 200 (body=%s)", rec.Code, rec.Body.String())
+	}
+	type resp struct {
+		Window       string  `json:"window"`
+		Current      struct{ Tokens int `json:"tokens"` } `json:"current"`
+		Previous     struct{ Tokens int `json:"tokens"` } `json:"previous"`
+		DeltaRatio   float64 `json:"delta_ratio"`
+		WeeklySonnet int     `json:"weekly_sonnet_tokens"`
+	}
+	got := decode[resp](t, rec)
+	if got.Window != "week" {
+		t.Errorf("window: got %q, want week", got.Window)
+	}
+	if got.Current.Tokens != 10000 {
+		t.Errorf("current tokens: got %d, want 10000", got.Current.Tokens)
+	}
+	if got.Previous.Tokens != 5000 {
+		t.Errorf("previous tokens: got %d, want 5000", got.Previous.Tokens)
+	}
+	if got.DeltaRatio != 1.0 {
+		t.Errorf("delta: got %f, want 1.0", got.DeltaRatio)
+	}
+	if got.WeeklySonnet != 4000 {
+		t.Errorf("weekly sonnet: got %d, want 4000", got.WeeklySonnet)
+	}
+}
+
+func TestBlocksFiltersPlaceholderSnapshots(t *testing.T) {
+	r := newTestRepo(t)
+	realStart := time.Date(2026, 4, 14, 10, 0, 0, 0, time.UTC)
+	realEnd := realStart.Add(5 * time.Hour)
+	// Placeholder (no active block): BlockEndedAt = nil, tokens = 0.
+	placeholder := time.Date(2026, 4, 14, 16, 30, 0, 0, time.UTC)
+	seedSnapshots(t, r,
+		repository.Snapshot{TakenAt: realStart, BlockStartedAt: realStart, BlockEndedAt: &realEnd, TokensUsed: 5000, UsageRatio: 0.1},
+		repository.Snapshot{TakenAt: placeholder, BlockStartedAt: placeholder, BlockEndedAt: nil, TokensUsed: 0},
+	)
+
+	h := server.NewHandler(r, server.Config{})
+	req := httptest.NewRequest(http.MethodGet, "/usage/blocks?from=2026-04-14&to=2026-04-15", nil)
+	rec := httptest.NewRecorder()
+	h.Routes().ServeHTTP(rec, req)
+
+	type resp struct {
+		Blocks []struct {
+			Tokens int `json:"tokens"`
+		} `json:"blocks"`
+	}
+	got := decode[resp](t, rec)
+	if len(got.Blocks) != 1 {
+		t.Fatalf("len blocks: got %d, want 1 (placeholder must be filtered)", len(got.Blocks))
+	}
+	if got.Blocks[0].Tokens != 5000 {
+		t.Errorf("blocks[0].tokens: got %d, want 5000", got.Blocks[0].Tokens)
+	}
+}
+
+func TestSummaryInvalidWindow(t *testing.T) {
+	r := newTestRepo(t)
+	h := server.NewHandler(r, server.Config{})
+	req := httptest.NewRequest(http.MethodGet, "/usage/summary?window=decade", nil)
+	rec := httptest.NewRecorder()
+	h.Routes().ServeHTTP(rec, req)
+	if rec.Code != http.StatusBadRequest {
+		t.Fatalf("status: got %d, want 400", rec.Code)
+	}
+}
+
+func TestHealthz(t *testing.T) {
+	r := newTestRepo(t)
+	h := server.NewHandler(r, server.Config{})
+	req := httptest.NewRequest(http.MethodGet, "/healthz", nil)
+	rec := httptest.NewRecorder()
+	h.Routes().ServeHTTP(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status: got %d, want 200", rec.Code)
+	}
+	if rec.Body.String() != "ok" {
+		t.Errorf("body: got %q, want ok", rec.Body.String())
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -1,0 +1,46 @@
+package server
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	"github.com/rengotaku/claude-usage-tracker/internal/repository"
+)
+
+// SnapshotLister is the minimal repository interface the handlers depend on.
+type SnapshotLister interface {
+	ListBetween(ctx context.Context, from, to time.Time) ([]repository.Snapshot, error)
+}
+
+// Config holds server configuration.
+type Config struct {
+	SessionLimit      int // 5h block limit (0 = unknown)
+	WeeklyLimit       int // weekly all-models limit (0 = unknown)
+	WeeklySonnetLimit int // weekly Sonnet limit (0 = unknown)
+}
+
+// Handler holds dependencies for HTTP handlers.
+type Handler struct {
+	repo SnapshotLister
+	cfg  Config
+}
+
+// NewHandler returns a Handler bound to the given repository and config.
+func NewHandler(repo SnapshotLister, cfg Config) *Handler {
+	return &Handler{repo: repo, cfg: cfg}
+}
+
+// Routes returns an http.ServeMux with all /usage/* routes registered.
+func (h *Handler) Routes() *http.ServeMux {
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /usage/snapshots", h.Snapshots)
+	mux.HandleFunc("GET /usage/blocks", h.Blocks)
+	mux.HandleFunc("GET /usage/daily", h.Daily)
+	mux.HandleFunc("GET /usage/summary", h.Summary)
+	mux.HandleFunc("GET /healthz", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte("ok"))
+	})
+	return mux
+}


### PR DESCRIPTION
Closes #14

## 概要

SQLite に蓄積された hourly snapshot を HTTP API 経由で取得できるようにする。

## 設計（Issue#14 コメントで合意済み）

### エンドポイント

| パス | 用途 |
|---|---|
| `GET /usage/snapshots` | 生の hourly snapshot（詳細分析） |
| `GET /usage/blocks` | 5h ブロック単位の消費率（1週間ビュー用・新規） |
| `GET /usage/daily` | 日毎集約（日次グラフ用） |
| `GET /usage/summary?window=week\|month\|6month\|year` | 期間サマリ＋前期比 |

### 実装方針

- `cmd/server/main.go` を追加（HTTP サーバー）
- ルーティング: `chi`
- `internal/repository.ListBetween` を流用
- デフォルトポート: `8080`（`CLAUDE_USAGE_TRACKER_PORT` で変更可）

## 完了条件

- [ ] `go run ./cmd/server` でサーバー起動
- [ ] `curl` で各エンドポイントを叩いて JSON が返る
- [ ] `from` / `to` 省略時は直近24時間を返す
- [ ] 5h ブロック集計ロジックの単体テスト