### PR TITLE
feat: cmd/current のプラン自動検出 (closes #16)

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,8 +14,25 @@ Claudeのusage状態を定期的に記録するリポジトリ
 | 変数 | デフォルト | 説明 |
 |---|---|---|
 | `CLAUDE_USAGE_TRACKER_LOG_DIR` | `~/.claude/projects` | JSONL ログディレクトリ |
-| `CLAUDE_USAGE_TRACKER_PLAN_LIMIT` | `200000000` | プランのトークン上限 |
+| `CLAUDE_USAGE_TRACKER_PLAN_LIMIT` | プラン自動検出（下表参照） | 5h セッションのトークン上限 |
+| `CLAUDE_USAGE_TRACKER_WEEKLY_LIMIT` | なし（0 表示） | 週次 全モデル合算上限 |
+| `CLAUDE_USAGE_TRACKER_WEEKLY_SONNET_LIMIT` | なし（0 表示） | 週次 Sonnet 上限 |
 | `CLAUDE_USAGE_TRACKER_DB` | `~/.local/share/claude-usage-tracker/snapshots.db` | SQLite DB パス |
+
+## プラン自動検出
+
+`CLAUDE_USAGE_TRACKER_PLAN_LIMIT` 未設定時は `~/.claude/.credentials.json` の `rateLimitTier` からデフォルト値を適用する。
+
+| tier | セッション上限 (内蔵値) |
+|---|---|
+| `default_claude_pro` | 19M |
+| `default_claude_max_5x` | 88M |
+| `default_claude_max_20x` | 220M |
+
+- 数値は Anthropic 非公開の概算値。プラン変更後は `claude login` での再認証が必要（[claude-code#43639](https://github.com/anthropics/claude-code/issues/43639)）。
+- env 変数は常に優先される。
+- 週次 limit はマップなし — env で明示指定する。
+- 検出結果は stderr に JSON ログ（`plan detected`）として出力される。
 
 ## インストール（systemd timer）
 

--- a/cmd/current/main.go
+++ b/cmd/current/main.go
@@ -35,6 +35,7 @@ func main() {
 	jsonFlag := len(os.Args) > 1 && os.Args[1] == "--json"
 
 	cfg := service.ConfigFromEnv()
+	logPlanDetection(logger, cfg)
 	result, err := service.Compute(cfg)
 	if err != nil {
 		logger.Error("compute usage", "error", err)
@@ -91,6 +92,24 @@ func weeklyLine(tokens, limit int, ratio float64, resetsAt string) string {
 		return fmt.Sprintf("%.0f%% used (%s / %s, resets %s (Asia/Tokyo))", ratio*100, formatM(tokens), formatM(limit), resetsAt)
 	}
 	return fmt.Sprintf("%s used (resets %s (Asia/Tokyo))", formatM(tokens), resetsAt)
+}
+
+// logPlanDetection surfaces the detected tier and resolved session limit
+// so users can spot misdetection — the rateLimitTier field in
+// ~/.claude/.credentials.json is non-public and can become stale.
+func logPlanDetection(logger *slog.Logger, cfg service.Config) {
+	if cfg.DetectedTier == "" {
+		return
+	}
+	source := "detected"
+	if cfg.SessionLimitFromEnv {
+		source = "env_override"
+	}
+	logger.Info("plan detected",
+		"tier", cfg.DetectedTier,
+		"session_limit", cfg.SessionLimit,
+		"source", source,
+	)
 }
 
 func formatM(n int) string {

--- a/internal/plan/plan.go
+++ b/internal/plan/plan.go
@@ -1,0 +1,64 @@
+// Package plan detects the Claude subscription tier from local credentials
+// and exposes the community-known session token limits per tier.
+//
+// The tier identifier is read from ~/.claude/.credentials.json's
+// claudeAiOauth.rateLimitTier field. The numeric session limits are
+// community estimates (Anthropic does not publish exact values) and may
+// drift over time; env vars in the service package always take precedence.
+package plan
+
+import (
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+)
+
+const (
+	TierPro    = "default_claude_pro"
+	TierMax5x  = "default_claude_max_5x"
+	TierMax20x = "default_claude_max_20x"
+)
+
+var sessionLimits = map[string]int{
+	TierPro:    19_000_000,
+	TierMax5x:  88_000_000,
+	TierMax20x: 220_000_000,
+}
+
+// DetectTier reads ~/.claude/.credentials.json and returns rateLimitTier.
+func DetectTier() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return DetectTierAt(filepath.Join(home, ".claude", ".credentials.json"))
+}
+
+// DetectTierAt reads a credentials JSON file at the given path and returns
+// the rateLimitTier. Returns an error if the file is missing, malformed, or
+// the tier field is absent.
+func DetectTierAt(path string) (string, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return "", err
+	}
+	var creds struct {
+		ClaudeAIOauth struct {
+			RateLimitTier string `json:"rateLimitTier"`
+		} `json:"claudeAiOauth"`
+	}
+	if err := json.Unmarshal(data, &creds); err != nil {
+		return "", err
+	}
+	if creds.ClaudeAIOauth.RateLimitTier == "" {
+		return "", errors.New("rateLimitTier not found in credentials")
+	}
+	return creds.ClaudeAIOauth.RateLimitTier, nil
+}
+
+// SessionLimitForTier returns the 5-hour session token limit for a known
+// tier, or 0 if the tier is unknown.
+func SessionLimitForTier(tier string) int {
+	return sessionLimits[tier]
+}

--- a/internal/plan/plan_test.go
+++ b/internal/plan/plan_test.go
@@ -1,0 +1,112 @@
+package plan_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/rengotaku/claude-usage-tracker/internal/plan"
+)
+
+func TestDetectTierAt_Max5x(t *testing.T) {
+	path := writeCredentials(t, `{"claudeAiOauth":{"rateLimitTier":"default_claude_max_5x"}}`)
+
+	tier, err := plan.DetectTierAt(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if tier != "default_claude_max_5x" {
+		t.Errorf("expected default_claude_max_5x, got %s", tier)
+	}
+}
+
+func TestDetectTierAt_Pro(t *testing.T) {
+	path := writeCredentials(t, `{"claudeAiOauth":{"rateLimitTier":"default_claude_pro"}}`)
+
+	tier, err := plan.DetectTierAt(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if tier != "default_claude_pro" {
+		t.Errorf("expected default_claude_pro, got %s", tier)
+	}
+}
+
+func TestDetectTierAt_MissingFile(t *testing.T) {
+	tier, err := plan.DetectTierAt(filepath.Join(t.TempDir(), "nonexistent.json"))
+	if err == nil {
+		t.Error("expected error for missing file")
+	}
+	if tier != "" {
+		t.Errorf("expected empty tier, got %s", tier)
+	}
+}
+
+func TestDetectTierAt_NoTierField(t *testing.T) {
+	path := writeCredentials(t, `{"claudeAiOauth":{}}`)
+
+	tier, err := plan.DetectTierAt(path)
+	if err == nil {
+		t.Error("expected error when rateLimitTier missing")
+	}
+	if tier != "" {
+		t.Errorf("expected empty tier, got %s", tier)
+	}
+}
+
+func TestDetectTierAt_InvalidJSON(t *testing.T) {
+	path := writeCredentials(t, `not json`)
+
+	_, err := plan.DetectTierAt(path)
+	if err == nil {
+		t.Error("expected error for invalid JSON")
+	}
+}
+
+func TestSessionLimitForTier(t *testing.T) {
+	tests := []struct {
+		tier string
+		want int
+	}{
+		{"default_claude_pro", 19_000_000},
+		{"default_claude_max_5x", 88_000_000},
+		{"default_claude_max_20x", 220_000_000},
+		{"unknown_tier", 0},
+		{"", 0},
+	}
+	for _, tt := range tests {
+		if got := plan.SessionLimitForTier(tt.tier); got != tt.want {
+			t.Errorf("SessionLimitForTier(%q) = %d, want %d", tt.tier, got, tt.want)
+		}
+	}
+}
+
+func TestDetectTier_UsesHomeDir(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	credDir := filepath.Join(home, ".claude")
+	if err := os.MkdirAll(credDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(credDir, ".credentials.json")
+	if err := os.WriteFile(path, []byte(`{"claudeAiOauth":{"rateLimitTier":"default_claude_max_20x"}}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	tier, err := plan.DetectTier()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if tier != "default_claude_max_20x" {
+		t.Errorf("expected default_claude_max_20x, got %s", tier)
+	}
+}
+
+func writeCredentials(t *testing.T, body string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), ".credentials.json")
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}

--- a/internal/service/usage.go
+++ b/internal/service/usage.go
@@ -9,30 +9,52 @@ import (
 
 	"github.com/rengotaku/claude-usage-tracker/internal/blocks"
 	"github.com/rengotaku/claude-usage-tracker/internal/jsonl"
+	"github.com/rengotaku/claude-usage-tracker/internal/plan"
 )
 
 var jst = time.FixedZone("JST", 9*60*60)
 
 // Config holds runtime configuration for usage computation.
 type Config struct {
-	LogDir              string
-	SessionLimit        int // 5-hour block limit (0 = unknown)
-	WeeklyLimit         int // weekly all-models limit (0 = unknown)
-	WeeklySonnetLimit   int // weekly Sonnet-only limit (0 = unknown)
+	LogDir            string
+	SessionLimit      int // 5-hour block limit (0 = unknown)
+	WeeklyLimit       int // weekly all-models limit (0 = unknown)
+	WeeklySonnetLimit int // weekly Sonnet-only limit (0 = unknown)
+
+	// DetectedTier is the rateLimitTier read from ~/.claude/.credentials.json
+	// (empty if the file is missing or unreadable). Surfaced for logging so
+	// users can confirm the detected plan even when env vars override it.
+	DetectedTier string
+	// SessionLimitFromEnv reports whether SessionLimit came from the env var
+	// (true) or from the tier map fallback (false).
+	SessionLimitFromEnv bool
 }
 
-// ConfigFromEnv builds Config from environment variables.
+// ConfigFromEnv builds Config from environment variables, falling back to
+// tier-based session limits detected from ~/.claude/.credentials.json when
+// CLAUDE_USAGE_TRACKER_PLAN_LIMIT is not set. Env vars always win.
 func ConfigFromEnv() Config {
 	logDir := os.Getenv("CLAUDE_USAGE_TRACKER_LOG_DIR")
 	if logDir == "" {
 		home, _ := os.UserHomeDir()
 		logDir = home + "/.claude/projects"
 	}
+
+	envLimit := envInt("CLAUDE_USAGE_TRACKER_PLAN_LIMIT", 0)
+	detectedTier, _ := plan.DetectTier()
+
+	sessionLimit := envLimit
+	if sessionLimit == 0 && detectedTier != "" {
+		sessionLimit = plan.SessionLimitForTier(detectedTier)
+	}
+
 	return Config{
-		LogDir:            logDir,
-		SessionLimit:      envInt("CLAUDE_USAGE_TRACKER_PLAN_LIMIT", 0),
-		WeeklyLimit:       envInt("CLAUDE_USAGE_TRACKER_WEEKLY_LIMIT", 0),
-		WeeklySonnetLimit: envInt("CLAUDE_USAGE_TRACKER_WEEKLY_SONNET_LIMIT", 0),
+		LogDir:              logDir,
+		SessionLimit:        sessionLimit,
+		WeeklyLimit:         envInt("CLAUDE_USAGE_TRACKER_WEEKLY_LIMIT", 0),
+		WeeklySonnetLimit:   envInt("CLAUDE_USAGE_TRACKER_WEEKLY_SONNET_LIMIT", 0),
+		DetectedTier:        detectedTier,
+		SessionLimitFromEnv: envLimit > 0,
 	}
 }
 

--- a/internal/service/usage_test.go
+++ b/internal/service/usage_test.go
@@ -93,6 +93,8 @@ func TestCompute_WeeklyLimit(t *testing.T) {
 }
 
 func TestConfigFromEnv_Defaults(t *testing.T) {
+	// Isolate HOME so credentials detection cannot interfere.
+	t.Setenv("HOME", t.TempDir())
 	t.Setenv("CLAUDE_USAGE_TRACKER_LOG_DIR", "")
 	t.Setenv("CLAUDE_USAGE_TRACKER_PLAN_LIMIT", "")
 
@@ -103,9 +105,68 @@ func TestConfigFromEnv_Defaults(t *testing.T) {
 	if cfg.LogDir == "" {
 		t.Error("expected non-empty log dir")
 	}
+	if cfg.DetectedTier != "" {
+		t.Errorf("expected empty DetectedTier, got %s", cfg.DetectedTier)
+	}
+	if cfg.SessionLimitFromEnv {
+		t.Error("expected SessionLimitFromEnv=false when env unset")
+	}
+}
+
+func TestConfigFromEnv_DetectsPlanWhenEnvUnset(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("CLAUDE_USAGE_TRACKER_PLAN_LIMIT", "")
+	writeCredentials(t, home, `{"claudeAiOauth":{"rateLimitTier":"default_claude_max_5x"}}`)
+
+	cfg := service.ConfigFromEnv()
+	if cfg.DetectedTier != "default_claude_max_5x" {
+		t.Errorf("expected detected tier max_5x, got %s", cfg.DetectedTier)
+	}
+	if cfg.SessionLimit != 88_000_000 {
+		t.Errorf("expected session limit 88M, got %d", cfg.SessionLimit)
+	}
+	if cfg.SessionLimitFromEnv {
+		t.Error("expected SessionLimitFromEnv=false (detected, not env)")
+	}
+}
+
+func TestConfigFromEnv_EnvWinsOverDetection(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("CLAUDE_USAGE_TRACKER_PLAN_LIMIT", "50000000")
+	writeCredentials(t, home, `{"claudeAiOauth":{"rateLimitTier":"default_claude_max_20x"}}`)
+
+	cfg := service.ConfigFromEnv()
+	if cfg.SessionLimit != 50_000_000 {
+		t.Errorf("expected env-set limit 50M, got %d", cfg.SessionLimit)
+	}
+	if !cfg.SessionLimitFromEnv {
+		t.Error("expected SessionLimitFromEnv=true")
+	}
+	// Detected tier is still reported for visibility, even when overridden.
+	if cfg.DetectedTier != "default_claude_max_20x" {
+		t.Errorf("expected detected tier still surfaced, got %s", cfg.DetectedTier)
+	}
+}
+
+func TestConfigFromEnv_UnknownTier(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("CLAUDE_USAGE_TRACKER_PLAN_LIMIT", "")
+	writeCredentials(t, home, `{"claudeAiOauth":{"rateLimitTier":"future_tier"}}`)
+
+	cfg := service.ConfigFromEnv()
+	if cfg.DetectedTier != "future_tier" {
+		t.Errorf("expected tier future_tier, got %s", cfg.DetectedTier)
+	}
+	if cfg.SessionLimit != 0 {
+		t.Errorf("expected 0 session limit for unknown tier, got %d", cfg.SessionLimit)
+	}
 }
 
 func TestConfigFromEnv_EnvOverride(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
 	t.Setenv("CLAUDE_USAGE_TRACKER_LOG_DIR", "/tmp/logs")
 	t.Setenv("CLAUDE_USAGE_TRACKER_PLAN_LIMIT", "53000000")
 	t.Setenv("CLAUDE_USAGE_TRACKER_WEEKLY_LIMIT", "1000000000")
@@ -123,6 +184,18 @@ func TestConfigFromEnv_EnvOverride(t *testing.T) {
 	}
 	if cfg.WeeklySonnetLimit != 500_000_000 {
 		t.Errorf("expected 500000000, got %d", cfg.WeeklySonnetLimit)
+	}
+}
+
+func writeCredentials(t *testing.T, home, body string) {
+	t.Helper()
+	credDir := filepath.Join(home, ".claude")
+	if err := os.MkdirAll(credDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(credDir, ".credentials.json")
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
 	}
 }
 


### PR DESCRIPTION
## Summary

- `~/.claude/.credentials.json` の `rateLimitTier` から 5h セッション上限を自動解決（A+B ハイブリッド方針）
- tier→limit マップを内蔵: `default_claude_pro=19M` / `default_claude_max_5x=88M` / `default_claude_max_20x=220M`
- `CLAUDE_USAGE_TRACKER_PLAN_LIMIT` は常に優先。未設定時のみ検出値へフォールバック
- 検出結果を stderr に JSON ログ（`plan detected` / `source=detected|env_override`）で出力し、誤検出に気付けるようにした

## 背景

env 未設定時、セッション/週次 ratio が 0% 表示され `/usage` と乖離していた（Issue #16）。
tier 検出により Pro/Max ユーザーは env 設定なしで正しい ratio が出るようになる。

## 既知の制約

- tier 数値は Anthropic 非公開の概算値（コミュニティ実測）
- `rateLimitTier` はプランアップグレード時に自動更新されない ([claude-code#43639](https://github.com/anthropics/claude-code/issues/43639))。再ログインが必要
- 週次 limit はマップ対象外（env でのみ設定）

## Test plan

- [x] `go test ./...` 全パス（plan パッケージ 7 ケース + service 3 ケース追加）
- [x] env 未設定時に `source=detected` で tier 検出ログ出力
- [x] env 設定時に `source=env_override` で env 値が優先
- [x] 未知 tier は session_limit=0（既存の unknown 挙動維持）
- [ ] 他環境（Pro / Max 20x）での動作確認はユーザー側で実施

Closes #16