### PR TITLE
fix: Max 5x の tier 上限を web /usage 実測値に修正 (closes #18)

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,23 +15,24 @@ Claudeのusage状態を定期的に記録するリポジトリ
 |---|---|---|
 | `CLAUDE_USAGE_TRACKER_LOG_DIR` | `~/.claude/projects` | JSONL ログディレクトリ |
 | `CLAUDE_USAGE_TRACKER_PLAN_LIMIT` | プラン自動検出（下表参照） | 5h セッションのトークン上限 |
-| `CLAUDE_USAGE_TRACKER_WEEKLY_LIMIT` | なし（0 表示） | 週次 全モデル合算上限 |
-| `CLAUDE_USAGE_TRACKER_WEEKLY_SONNET_LIMIT` | なし（0 表示） | 週次 Sonnet 上限 |
+| `CLAUDE_USAGE_TRACKER_WEEKLY_LIMIT` | プラン自動検出（下表参照） | 週次 全モデル合算上限 |
+| `CLAUDE_USAGE_TRACKER_WEEKLY_SONNET_LIMIT` | プラン自動検出（下表参照） | 週次 Sonnet 上限 |
 | `CLAUDE_USAGE_TRACKER_DB` | `~/.local/share/claude-usage-tracker/snapshots.db` | SQLite DB パス |
 
 ## プラン自動検出
 
-`CLAUDE_USAGE_TRACKER_PLAN_LIMIT` 未設定時は `~/.claude/.credentials.json` の `rateLimitTier` からデフォルト値を適用する。
+env 変数未設定時は `~/.claude/.credentials.json` の `rateLimitTier` からデフォルト値を適用する。
 
-| tier | セッション上限 (内蔵値) |
-|---|---|
-| `default_claude_pro` | 19M |
-| `default_claude_max_5x` | 88M |
-| `default_claude_max_20x` | 220M |
+| tier | セッション (5h) | 週次 All | 週次 Sonnet |
+|---|---|---|---|
+| `default_claude_pro` | 19M | — | — |
+| `default_claude_max_5x` | 45M | 833M | 695M |
+| `default_claude_max_20x` | 220M | — | — |
 
-- 数値は Anthropic 非公開の概算値。プラン変更後は `claude login` での再認証が必要（[claude-code#43639](https://github.com/anthropics/claude-code/issues/43639)）。
+- Max 5x の値は web `/usage` の `%` と照合済み (2026-04-22)。
+- Pro / Max 20x のセッション値はコミュニティ実測で未検証、週次は未測定（env で明示指定する）。
+- プラン変更後は `claude login` での再認証が必要（[claude-code#43639](https://github.com/anthropics/claude-code/issues/43639)）。
 - env 変数は常に優先される。
-- 週次 limit はマップなし — env で明示指定する。
 - 検出結果は stderr に JSON ログ（`plan detected`）として出力される。
 
 ## インストール（systemd timer）

--- a/internal/plan/plan.go
+++ b/internal/plan/plan.go
@@ -1,10 +1,12 @@
 // Package plan detects the Claude subscription tier from local credentials
-// and exposes the community-known session token limits per tier.
+// and exposes known session/weekly token limits per tier.
 //
 // The tier identifier is read from ~/.claude/.credentials.json's
-// claudeAiOauth.rateLimitTier field. The numeric session limits are
-// community estimates (Anthropic does not publish exact values) and may
-// drift over time; env vars in the service package always take precedence.
+// claudeAiOauth.rateLimitTier field. Numeric limits are derived from the
+// web /usage dashboard's percentage display (Anthropic does not publish
+// exact numbers) and may drift over time; env vars in the service package
+// always take precedence. Limits are only populated for tiers whose
+// percentages have been observed; others return 0.
 package plan
 
 import (
@@ -20,10 +22,24 @@ const (
 	TierMax20x = "default_claude_max_20x"
 )
 
+// sessionLimits map 5-hour session token caps.
+// Max 5x value verified against web /usage on 2026-04-22.
+// Pro / Max 20x are prior community estimates, not yet re-verified.
 var sessionLimits = map[string]int{
 	TierPro:    19_000_000,
-	TierMax5x:  88_000_000,
+	TierMax5x:  45_000_000,
 	TierMax20x: 220_000_000,
+}
+
+// weeklyLimits map all-models weekly token caps.
+// Only populated for tiers with /usage-confirmed values.
+var weeklyLimits = map[string]int{
+	TierMax5x: 833_000_000,
+}
+
+// weeklySonnetLimits map Sonnet-only weekly token caps.
+var weeklySonnetLimits = map[string]int{
+	TierMax5x: 695_000_000,
 }
 
 // DetectTier reads ~/.claude/.credentials.json and returns rateLimitTier.
@@ -61,4 +77,16 @@ func DetectTierAt(path string) (string, error) {
 // tier, or 0 if the tier is unknown.
 func SessionLimitForTier(tier string) int {
 	return sessionLimits[tier]
+}
+
+// WeeklyLimitForTier returns the all-models weekly token limit for a known
+// tier, or 0 if the tier is unknown / not yet measured.
+func WeeklyLimitForTier(tier string) int {
+	return weeklyLimits[tier]
+}
+
+// WeeklySonnetLimitForTier returns the Sonnet-only weekly token limit for a
+// known tier, or 0 if the tier is unknown / not yet measured.
+func WeeklySonnetLimitForTier(tier string) int {
+	return weeklySonnetLimits[tier]
 }

--- a/internal/plan/plan_test.go
+++ b/internal/plan/plan_test.go
@@ -69,7 +69,7 @@ func TestSessionLimitForTier(t *testing.T) {
 		want int
 	}{
 		{"default_claude_pro", 19_000_000},
-		{"default_claude_max_5x", 88_000_000},
+		{"default_claude_max_5x", 45_000_000},
 		{"default_claude_max_20x", 220_000_000},
 		{"unknown_tier", 0},
 		{"", 0},
@@ -77,6 +77,44 @@ func TestSessionLimitForTier(t *testing.T) {
 	for _, tt := range tests {
 		if got := plan.SessionLimitForTier(tt.tier); got != tt.want {
 			t.Errorf("SessionLimitForTier(%q) = %d, want %d", tt.tier, got, tt.want)
+		}
+	}
+}
+
+func TestWeeklyLimitForTier(t *testing.T) {
+	tests := []struct {
+		tier string
+		want int
+	}{
+		{"default_claude_max_5x", 833_000_000},
+		// Pro and Max 20x weekly limits are not yet confirmed from /usage
+		// web values; callers must rely on env vars for those tiers.
+		{"default_claude_pro", 0},
+		{"default_claude_max_20x", 0},
+		{"unknown_tier", 0},
+		{"", 0},
+	}
+	for _, tt := range tests {
+		if got := plan.WeeklyLimitForTier(tt.tier); got != tt.want {
+			t.Errorf("WeeklyLimitForTier(%q) = %d, want %d", tt.tier, got, tt.want)
+		}
+	}
+}
+
+func TestWeeklySonnetLimitForTier(t *testing.T) {
+	tests := []struct {
+		tier string
+		want int
+	}{
+		{"default_claude_max_5x", 695_000_000},
+		{"default_claude_pro", 0},
+		{"default_claude_max_20x", 0},
+		{"unknown_tier", 0},
+		{"", 0},
+	}
+	for _, tt := range tests {
+		if got := plan.WeeklySonnetLimitForTier(tt.tier); got != tt.want {
+			t.Errorf("WeeklySonnetLimitForTier(%q) = %d, want %d", tt.tier, got, tt.want)
 		}
 	}
 }

--- a/internal/service/usage.go
+++ b/internal/service/usage.go
@@ -41,18 +41,28 @@ func ConfigFromEnv() Config {
 	}
 
 	envLimit := envInt("CLAUDE_USAGE_TRACKER_PLAN_LIMIT", 0)
+	envWeekly := envInt("CLAUDE_USAGE_TRACKER_WEEKLY_LIMIT", 0)
+	envWeeklySonnet := envInt("CLAUDE_USAGE_TRACKER_WEEKLY_SONNET_LIMIT", 0)
 	detectedTier, _ := plan.DetectTier()
 
 	sessionLimit := envLimit
 	if sessionLimit == 0 && detectedTier != "" {
 		sessionLimit = plan.SessionLimitForTier(detectedTier)
 	}
+	weeklyLimit := envWeekly
+	if weeklyLimit == 0 && detectedTier != "" {
+		weeklyLimit = plan.WeeklyLimitForTier(detectedTier)
+	}
+	weeklySonnetLimit := envWeeklySonnet
+	if weeklySonnetLimit == 0 && detectedTier != "" {
+		weeklySonnetLimit = plan.WeeklySonnetLimitForTier(detectedTier)
+	}
 
 	return Config{
 		LogDir:              logDir,
 		SessionLimit:        sessionLimit,
-		WeeklyLimit:         envInt("CLAUDE_USAGE_TRACKER_WEEKLY_LIMIT", 0),
-		WeeklySonnetLimit:   envInt("CLAUDE_USAGE_TRACKER_WEEKLY_SONNET_LIMIT", 0),
+		WeeklyLimit:         weeklyLimit,
+		WeeklySonnetLimit:   weeklySonnetLimit,
 		DetectedTier:        detectedTier,
 		SessionLimitFromEnv: envLimit > 0,
 	}

--- a/internal/service/usage_test.go
+++ b/internal/service/usage_test.go
@@ -123,11 +123,54 @@ func TestConfigFromEnv_DetectsPlanWhenEnvUnset(t *testing.T) {
 	if cfg.DetectedTier != "default_claude_max_5x" {
 		t.Errorf("expected detected tier max_5x, got %s", cfg.DetectedTier)
 	}
-	if cfg.SessionLimit != 88_000_000 {
-		t.Errorf("expected session limit 88M, got %d", cfg.SessionLimit)
+	if cfg.SessionLimit != 45_000_000 {
+		t.Errorf("expected session limit 45M (Max 5x), got %d", cfg.SessionLimit)
+	}
+	if cfg.WeeklyLimit != 833_000_000 {
+		t.Errorf("expected weekly limit 833M (Max 5x), got %d", cfg.WeeklyLimit)
+	}
+	if cfg.WeeklySonnetLimit != 695_000_000 {
+		t.Errorf("expected weekly sonnet limit 695M (Max 5x), got %d", cfg.WeeklySonnetLimit)
 	}
 	if cfg.SessionLimitFromEnv {
 		t.Error("expected SessionLimitFromEnv=false (detected, not env)")
+	}
+}
+
+func TestConfigFromEnv_WeeklyEnvWinsOverDetection(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("CLAUDE_USAGE_TRACKER_WEEKLY_LIMIT", "900000000")
+	t.Setenv("CLAUDE_USAGE_TRACKER_WEEKLY_SONNET_LIMIT", "700000000")
+	writeCredentials(t, home, `{"claudeAiOauth":{"rateLimitTier":"default_claude_max_5x"}}`)
+
+	cfg := service.ConfigFromEnv()
+	if cfg.WeeklyLimit != 900_000_000 {
+		t.Errorf("expected env weekly 900M, got %d", cfg.WeeklyLimit)
+	}
+	if cfg.WeeklySonnetLimit != 700_000_000 {
+		t.Errorf("expected env sonnet 700M, got %d", cfg.WeeklySonnetLimit)
+	}
+}
+
+func TestConfigFromEnv_UnmappedTierLeavesWeeklyZero(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("CLAUDE_USAGE_TRACKER_WEEKLY_LIMIT", "")
+	t.Setenv("CLAUDE_USAGE_TRACKER_WEEKLY_SONNET_LIMIT", "")
+	// Pro weekly limits are not in the map yet.
+	writeCredentials(t, home, `{"claudeAiOauth":{"rateLimitTier":"default_claude_pro"}}`)
+
+	cfg := service.ConfigFromEnv()
+	if cfg.WeeklyLimit != 0 {
+		t.Errorf("expected weekly limit 0 for unmapped tier, got %d", cfg.WeeklyLimit)
+	}
+	if cfg.WeeklySonnetLimit != 0 {
+		t.Errorf("expected weekly sonnet limit 0 for unmapped tier, got %d", cfg.WeeklySonnetLimit)
+	}
+	// Session limit for Pro is still populated.
+	if cfg.SessionLimit != 19_000_000 {
+		t.Errorf("expected session limit 19M (Pro), got %d", cfg.SessionLimit)
 	}
 }
 


### PR DESCRIPTION
## Summary

- **fix**: Max 5x の session 上限 `88M → 45M` に修正（web `/usage` 11% と整合）
- **feat**: 週次 limit を tier マップに追加（Max 5x: weekly_all=833M / weekly_sonnet=695M）
- **feat**: `CLAUDE_USAGE_TRACKER_WEEKLY_LIMIT` / `CLAUDE_USAGE_TRACKER_WEEKLY_SONNET_LIMIT` も env 未設定時に自動検出値へフォールバック
- Pro / Max 20x は実測値未取得のため session 値据え置き、週次は未マップ（env で明示指定要）

## 背景

PR #17 で内蔵した tier マップの値が web `/usage` と乖離していた (Issue #18)。
web が週次 `%` を表示してくれるおかげで逆算が可能になり、Max 5x の実測値が確定。

## 実測値 vs web `/usage` (Max 5x, 2026-04-22)

| 項目 | 修正前 tracker | **修正後 tracker** | web |
|---|---|---|---|
| Session (5h) | 6% (5M / 88M) | **15% (7M / 45M)** | 11% |
| Weekly All | 450M (limit未設定) | **54% (451M / 833M)** | **54%** ✅ |
| Weekly Sonnet | 153M (limit未設定) | **22% (153M / 695M)** | **22%** ✅ |

Weekly は web と完全一致。Session の乖離 (15% vs 11%) は web スナップショット後の時間経過による追加消費で妥当範囲。

## Test plan

- [x] `go test ./...` 全パス（plan 9 ケース / service 11 ケース）
- [x] 新規テスト: `TestWeeklyLimitForTier` / `TestWeeklySonnetLimitForTier` / `TestConfigFromEnv_WeeklyEnvWinsOverDetection` / `TestConfigFromEnv_UnmappedTierLeavesWeeklyZero`
- [x] 実機 (Max 5x) で web と weekly `%` 一致を確認
- [x] env override (weekly) で tier マップを上書きできることを確認（テスト）

## 未対応 (将来 Issue)

- Pro / Max 20x ユーザーの `/usage` 値を収集して tier マップを埋める
- Session 境界判定の `/usage` との微差（本 PR では session 値の再検証で済むため保留）

Closes #18