### PR TITLE
fix: Max5x セッション上限を 45M → 90M に修正

### DIFF
--- a/internal/plan/plan.go
+++ b/internal/plan/plan.go
@@ -23,11 +23,11 @@ const (
 )
 
 // sessionLimits map 5-hour session token caps.
-// Max 5x value verified against web /usage on 2026-04-22.
+// Max 5x re-verified against web /usage on 2026-04-24: web showed 27% with 24.1M tokens → limit ≈ 90M.
 // Pro / Max 20x are prior community estimates, not yet re-verified.
 var sessionLimits = map[string]int{
 	TierPro:    19_000_000,
-	TierMax5x:  45_000_000,
+	TierMax5x:  90_000_000,
 	TierMax20x: 220_000_000,
 }
 

--- a/internal/plan/plan_test.go
+++ b/internal/plan/plan_test.go
@@ -69,7 +69,7 @@ func TestSessionLimitForTier(t *testing.T) {
 		want int
 	}{
 		{"default_claude_pro", 19_000_000},
-		{"default_claude_max_5x", 45_000_000},
+		{"default_claude_max_5x", 90_000_000},
 		{"default_claude_max_20x", 220_000_000},
 		{"unknown_tier", 0},
 		{"", 0},

--- a/internal/service/usage_test.go
+++ b/internal/service/usage_test.go
@@ -123,8 +123,8 @@ func TestConfigFromEnv_DetectsPlanWhenEnvUnset(t *testing.T) {
 	if cfg.DetectedTier != "default_claude_max_5x" {
 		t.Errorf("expected detected tier max_5x, got %s", cfg.DetectedTier)
 	}
-	if cfg.SessionLimit != 45_000_000 {
-		t.Errorf("expected session limit 45M (Max 5x), got %d", cfg.SessionLimit)
+	if cfg.SessionLimit != 90_000_000 {
+		t.Errorf("expected session limit 90M (Max 5x), got %d", cfg.SessionLimit)
 	}
 	if cfg.WeeklyLimit != 833_000_000 {
 		t.Errorf("expected weekly limit 833M (Max 5x), got %d", cfg.WeeklyLimit)


### PR DESCRIPTION
## Summary

- `internal/plan/plan.go` の `TierMax5x` セッション上限を `45_000_000` → `90_000_000` に修正
- web `/usage` で 24.1M トークン使用時に 27% と表示されたことから実際の上限は 90M と判明

Closes #25

## 検証方法

```
24.1M / 90M ≈ 26.8% ≈ 27%  (web 表示と一致)
24.1M / 45M ≈ 53.6%        (修正前: 約2倍のズレ)
```

## Test plan

- [ ] `claude-usage-tracker-current` の出力 `limit` が `90000000` になっていること
- [ ] `claude.ai/usage` の % と tracker の % が概ね一致すること（±5% 程度）