### PR TITLE
feat: setup コマンドを追加（web /usage テキストから env var を推薦）

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,54 +6,13 @@ Claudeのusage状態を定期的に記録するリポジトリ
 
 | コマンド | 説明 |
 |---|---|
+| `claude-usage-tracker-setup` | `claude.ai/usage` のテキストを貼り付けて設定ファイルを生成 |
 | `claude-usage-tracker-current` | 現在の使用率を表示（`--json` で JSON 出力） |
 | `claude-usage-tracker-snapshot` | 使用率を計測して SQLite に保存 |
 
-## 環境変数
+## セットアップ
 
-| 変数 | デフォルト | 説明 |
-|---|---|---|
-| `CLAUDE_USAGE_TRACKER_LOG_DIR` | `~/.claude/projects` | JSONL ログディレクトリ |
-| `CLAUDE_USAGE_TRACKER_PLAN_LIMIT` | プラン自動検出（下表参照） | 5h セッションのトークン上限 |
-| `CLAUDE_USAGE_TRACKER_WEEKLY_LIMIT` | プラン自動検出（下表参照） | 週次 全モデル合算上限 |
-| `CLAUDE_USAGE_TRACKER_WEEKLY_SONNET_LIMIT` | プラン自動検出（下表参照） | 週次 Sonnet 上限 |
-| `CLAUDE_USAGE_TRACKER_DB` | `~/.local/share/claude-usage-tracker/snapshots.db` | SQLite DB パス |
-
-## プラン自動検出
-
-env 変数未設定時は `~/.claude/.credentials.json` の `rateLimitTier` からデフォルト値を適用する。
-
-| tier | セッション (5h) | 週次 All | 週次 Sonnet |
-|---|---|---|---|
-| `default_claude_pro` | 19M | — | — |
-| `default_claude_max_5x` | 45M | 833M | 695M |
-| `default_claude_max_20x` | 220M | — | — |
-
-- Max 5x の値は web `/usage` の `%` と照合済み (2026-04-22)。
-- Pro / Max 20x のセッション値はコミュニティ実測で未検証、週次は未測定（env で明示指定する）。
-- プラン変更後は `claude login` での再認証が必要（[claude-code#43639](https://github.com/anthropics/claude-code/issues/43639)）。
-- env 変数は常に優先される。
-- 検出結果は stderr に JSON ログ（`plan detected`）として出力される。
-
-### Team / Enterprise プランの場合
-
-Team・Enterprise プランは `claude auth login` によるブラウザ OAuth 認証（SSO）を使用するため、`~/.claude/.credentials.json` に `rateLimitTier` が存在しない。そのため自動検出は機能せず、`session_ratio` が常に `0` になる。
-
-web の `/usage` ページで表示される `%` から上限を逆算し、env 変数で明示指定する：
-
-```bash
-# 例: web で「Session 16% / 9M used」と表示されている場合
-# 上限 = 9,000,000 / 0.16 ≈ 56,000,000
-export CLAUDE_USAGE_TRACKER_PLAN_LIMIT=56000000
-export CLAUDE_USAGE_TRACKER_WEEKLY_LIMIT=754000000
-export CLAUDE_USAGE_TRACKER_WEEKLY_SONNET_LIMIT=367000000
-```
-
-macOS（launchd）では `~/Library/LaunchAgents/com.user.claude-usage-tracker.plist` の `EnvironmentVariables` に追記する。
-
-## インストール
-
-`make install` を実行すると OS を自動判別してインストールする。
+### 1. インストール
 
 ```bash
 make install
@@ -61,6 +20,64 @@ make install
 
 - バイナリを `~/.local/bin/` に配置
 - 定期実行エージェントを有効化（毎時0分）
+
+### 2. 設定ファイルの生成
+
+```bash
+claude-usage-tracker-setup
+```
+
+[claude.ai/usage](https://claude.ai/usage) のページテキストを貼り付けて Ctrl+D を押すと、
+`~/.config/claude-usage-tracker/config.yaml` が自動生成されます。
+
+## 設定ファイル
+
+`~/.config/claude-usage-tracker/config.yaml`
+
+```yaml
+# weekly リセット曜日・時刻（claude-usage-tracker-setup で自動設定）
+weekly_reset_day: Thursday
+weekly_reset_hour: 7
+
+# 以下は任意設定
+# log_dir: ~/.claude/projects
+# db: ~/.local/share/claude-usage-tracker/snapshots.db
+# plan_limit: 0          # 手動オーバーライド（0 = 自動検出）
+# weekly_limit: 0        # 週次全モデル上限（0 = 自動検出）
+# weekly_sonnet_limit: 0 # 週次 Sonnet 上限（0 = 自動検出）
+# port: "8080"           # HTTP サーバーポート
+```
+
+設定ファイルパスは `CLAUDE_USAGE_TRACKER_CONFIG` 環境変数でオーバーライド可能。
+
+## プラン自動検出
+
+`plan_limit` 未設定時は `~/.claude/.credentials.json` の `rateLimitTier` からデフォルト値を適用する。
+
+| tier | セッション (5h) | 週次 All | 週次 Sonnet |
+|---|---|---|---|
+| `default_claude_pro` | 19M | — | — |
+| `default_claude_max_5x` | 90M | 833M | 695M |
+| `default_claude_max_20x` | 220M | — | — |
+
+- 値は web `/usage` の `%` 表示から実測（概算）。
+- プラン変更後は `claude login` での再認証が必要（[claude-code#43639](https://github.com/anthropics/claude-code/issues/43639)）。
+- 検出結果は stderr に JSON ログ（`plan detected`）として出力される。
+
+### Team / Enterprise プランの場合
+
+`~/.claude/.credentials.json` に `rateLimitTier` が存在しないため自動検出が機能しない。
+web の `/usage` ページで表示される `%` から上限を逆算し、`config.yaml` に明示指定する：
+
+```yaml
+# 例: web で「Session 16% / 9M used」と表示されている場合
+# 上限 = 9,000,000 / 0.16 ≈ 56,000,000
+plan_limit: 56000000
+weekly_limit: 754000000
+weekly_sonnet_limit: 367000000
+```
+
+## インストール詳細
 
 ### Linux（systemd timer）
 

--- a/cmd/current/main.go
+++ b/cmd/current/main.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/rengotaku/claude-usage-tracker/internal/config"
 	"github.com/rengotaku/claude-usage-tracker/internal/service"
 )
 
@@ -20,13 +21,13 @@ type jsonOutput struct {
 		EndsAt     string  `json:"ends_at,omitempty"`
 	} `json:"session"`
 	Weekly struct {
-		TokensUsed    int     `json:"tokens_used"`
-		Limit         int     `json:"limit,omitempty"`
-		Ratio         float64 `json:"ratio,omitempty"`
-		SonnetTokens  int     `json:"sonnet_tokens_used"`
-		SonnetLimit   int     `json:"sonnet_limit,omitempty"`
-		SonnetRatio   float64 `json:"sonnet_ratio,omitempty"`
-		ResetsAt      string  `json:"resets_at"`
+		TokensUsed   int     `json:"tokens_used"`
+		Limit        int     `json:"limit,omitempty"`
+		Ratio        float64 `json:"ratio,omitempty"`
+		SonnetTokens int     `json:"sonnet_tokens_used"`
+		SonnetLimit  int     `json:"sonnet_limit,omitempty"`
+		SonnetRatio  float64 `json:"sonnet_ratio,omitempty"`
+		ResetsAt     string  `json:"resets_at"`
 	} `json:"weekly"`
 }
 
@@ -34,7 +35,13 @@ func main() {
 	logger := slog.New(slog.NewJSONHandler(os.Stderr, nil))
 	jsonFlag := len(os.Args) > 1 && os.Args[1] == "--json"
 
-	cfg := service.ConfigFromEnv()
+	appCfg, err := config.Load(config.DefaultPath())
+	if err != nil {
+		logger.Error("load config", "error", err)
+		os.Exit(1)
+	}
+
+	cfg := service.ConfigFrom(appCfg)
 	logPlanDetection(logger, cfg)
 	result, err := service.Compute(cfg)
 	if err != nil {
@@ -67,9 +74,7 @@ func main() {
 		return
 	}
 
-	// Human-readable: match /usage format
 	resetsAt := result.WeeklyResetsAt.In(jst).Format("Jan 2, 3pm")
-
 	fmt.Printf("Current session   %s\n", sessionLine(result))
 	fmt.Printf("Weekly (All)      %s\n", weeklyLine(result.WeeklyTokens, result.WeeklyLimit, result.WeeklyRatio, resetsAt))
 	fmt.Printf("Weekly (Sonnet)   %s\n", weeklyLine(result.WeeklySonnetTokens, result.WeeklySonnetLimit, result.WeeklySonnetRatio, resetsAt))
@@ -94,21 +99,13 @@ func weeklyLine(tokens, limit int, ratio float64, resetsAt string) string {
 	return fmt.Sprintf("%s used (resets %s (Asia/Tokyo))", formatM(tokens), resetsAt)
 }
 
-// logPlanDetection surfaces the detected tier and resolved session limit
-// so users can spot misdetection — the rateLimitTier field in
-// ~/.claude/.credentials.json is non-public and can become stale.
 func logPlanDetection(logger *slog.Logger, cfg service.Config) {
 	if cfg.DetectedTier == "" {
 		return
 	}
-	source := "detected"
-	if cfg.SessionLimitFromEnv {
-		source = "env_override"
-	}
 	logger.Info("plan detected",
 		"tier", cfg.DetectedTier,
 		"session_limit", cfg.SessionLimit,
-		"source", source,
 	)
 }
 

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -5,59 +5,49 @@ import (
 	"log/slog"
 	"net/http"
 	"os"
-	"strconv"
 	"time"
 
+	"github.com/rengotaku/claude-usage-tracker/internal/config"
 	"github.com/rengotaku/claude-usage-tracker/internal/repository"
 	"github.com/rengotaku/claude-usage-tracker/internal/server"
-)
-
-const (
-	defaultPort = "8080"
-	envPort     = "CLAUDE_USAGE_TRACKER_PORT"
 )
 
 func main() {
 	logger := slog.New(slog.NewJSONHandler(os.Stderr, nil))
 
-	port := os.Getenv(envPort)
-	if port == "" {
-		port = defaultPort
+	appCfg, err := config.Load(config.DefaultPath())
+	if err != nil {
+		logger.Error("load config", "error", err)
+		os.Exit(1)
 	}
 
-	dbPath := repository.DBPath()
-	repo, err := repository.NewSnapshotRepository(context.Background(), dbPath)
+	repo, err := repository.NewSnapshotRepository(context.Background(), appCfg.DB)
 	if err != nil {
-		logger.Error("open repository", "path", dbPath, "error", err)
+		logger.Error("open repository", "path", appCfg.DB, "error", err)
 		os.Exit(1)
 	}
 	defer repo.Close()
 
 	cfg := server.Config{
-		SessionLimit:      envInt("CLAUDE_USAGE_TRACKER_PLAN_LIMIT"),
-		WeeklyLimit:       envInt("CLAUDE_USAGE_TRACKER_WEEKLY_LIMIT"),
-		WeeklySonnetLimit: envInt("CLAUDE_USAGE_TRACKER_WEEKLY_SONNET_LIMIT"),
+		SessionLimit:      appCfg.PlanLimit,
+		WeeklyLimit:       appCfg.WeeklyLimit,
+		WeeklySonnetLimit: appCfg.WeeklySonnetLimit,
 	}
 	h := server.NewHandler(repo, cfg)
 
+	port := appCfg.Port
+	if port == "" {
+		port = "8080"
+	}
 	srv := &http.Server{
 		Addr:              ":" + port,
 		Handler:           h.Routes(),
 		ReadHeaderTimeout: 5 * time.Second,
 	}
 
-	logger.Info("server listening", "addr", srv.Addr, "db", dbPath)
+	logger.Info("server listening", "addr", srv.Addr, "db", appCfg.DB)
 	if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
 		logger.Error("serve", "error", err)
 		os.Exit(1)
 	}
-}
-
-func envInt(key string) int {
-	if v := os.Getenv(key); v != "" {
-		if n, err := strconv.Atoi(v); err == nil && n > 0 {
-			return n
-		}
-	}
-	return 0
 }

--- a/cmd/setup/main.go
+++ b/cmd/setup/main.go
@@ -4,7 +4,11 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 
+	"gopkg.in/yaml.v3"
+
+	"github.com/rengotaku/claude-usage-tracker/internal/config"
 	"github.com/rengotaku/claude-usage-tracker/internal/setup"
 )
 
@@ -29,35 +33,41 @@ func main() {
 		os.Exit(1)
 	}
 
-	printRecommendations(r)
+	if err := writeConfig(r); err != nil {
+		fmt.Fprintf(os.Stderr, "ERROR: %v\n", err)
+		os.Exit(1)
+	}
 }
 
-func printRecommendations(r setup.Result) {
+func writeConfig(r setup.Result) error {
+	cfgPath := config.DefaultPath()
+	if err := os.MkdirAll(filepath.Dir(cfgPath), 0o755); err != nil {
+		return fmt.Errorf("create config dir: %w", err)
+	}
+
+	// Load existing config to preserve user settings.
+	existing, _ := config.Load(cfgPath)
+
+	if r.HasReset {
+		existing.WeeklyResetDay = r.WeeklyResetDay.String()
+		existing.WeeklyResetHour = r.WeeklyResetHour
+	}
+
+	out, err := yaml.Marshal(existing)
+	if err != nil {
+		return fmt.Errorf("marshal config: %w", err)
+	}
+	if err := os.WriteFile(cfgPath, out, 0o644); err != nil {
+		return fmt.Errorf("write config: %w", err)
+	}
+
+	fmt.Printf("Wrote %s\n", cfgPath)
 	if r.Plan != "" {
-		fmt.Printf("# Plan: %s\n", r.Plan)
+		fmt.Printf("  plan:              %s\n", r.Plan)
 	}
 	if r.HasReset {
-		fmt.Printf("# Weekly reset: %s %02d:00 (web UI timezone — adjust to JST if needed)\n", r.WeeklyResetDay, r.WeeklyResetHour)
+		fmt.Printf("  weekly_reset_day:  %s\n", r.WeeklyResetDay)
+		fmt.Printf("  weekly_reset_hour: %d\n", r.WeeklyResetHour)
 	}
-	fmt.Println()
-
-	fmt.Println("# ---- ~/.bashrc or ~/.zshrc ----")
-	if r.HasReset {
-		fmt.Printf("export CLAUDE_USAGE_TRACKER_WEEKLY_RESET_DAY=%s\n", r.WeeklyResetDay)
-		fmt.Printf("export CLAUDE_USAGE_TRACKER_WEEKLY_RESET_HOUR=%d\n", r.WeeklyResetHour)
-	}
-	fmt.Println()
-
-	fmt.Println("# ---- systemd: deploy/systemd/claude-usage-tracker.service ----")
-	if r.HasReset {
-		fmt.Printf("Environment=CLAUDE_USAGE_TRACKER_WEEKLY_RESET_DAY=%s\n", r.WeeklyResetDay)
-		fmt.Printf("Environment=CLAUDE_USAGE_TRACKER_WEEKLY_RESET_HOUR=%d\n", r.WeeklyResetHour)
-	}
-	fmt.Println()
-
-	fmt.Println("# ---- launchd: deploy/launchd/com.user.claude-usage-tracker.plist ----")
-	if r.HasReset {
-		fmt.Printf("<key>CLAUDE_USAGE_TRACKER_WEEKLY_RESET_DAY</key>\n<string>%s</string>\n", r.WeeklyResetDay)
-		fmt.Printf("<key>CLAUDE_USAGE_TRACKER_WEEKLY_RESET_HOUR</key>\n<string>%d</string>\n", r.WeeklyResetHour)
-	}
+	return nil
 }

--- a/cmd/setup/main.go
+++ b/cmd/setup/main.go
@@ -1,0 +1,63 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/rengotaku/claude-usage-tracker/internal/setup"
+)
+
+func main() {
+	fmt.Fprintln(os.Stderr, "Claude Usage Tracker Setup")
+	fmt.Fprintln(os.Stderr, "")
+	fmt.Fprintln(os.Stderr, "1. Open https://claude.ai/usage in your browser")
+	fmt.Fprintln(os.Stderr, "2. Copy all the text on the page and paste it below")
+	fmt.Fprintln(os.Stderr, "3. Press Ctrl+D when done")
+	fmt.Fprintln(os.Stderr, "")
+
+	data, err := io.ReadAll(os.Stdin)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error reading input: %v\n", err)
+		os.Exit(1)
+	}
+
+	r := setup.ParseWebText(string(data))
+	if !r.HasReset && r.Tier == "" {
+		fmt.Fprintln(os.Stderr, "ERROR: Could not parse usage data.")
+		fmt.Fprintln(os.Stderr, "Please paste the full text from https://claude.ai/usage")
+		os.Exit(1)
+	}
+
+	printRecommendations(r)
+}
+
+func printRecommendations(r setup.Result) {
+	if r.Plan != "" {
+		fmt.Printf("# Plan: %s\n", r.Plan)
+	}
+	if r.HasReset {
+		fmt.Printf("# Weekly reset: %s %02d:00 (web UI timezone — adjust to JST if needed)\n", r.WeeklyResetDay, r.WeeklyResetHour)
+	}
+	fmt.Println()
+
+	fmt.Println("# ---- ~/.bashrc or ~/.zshrc ----")
+	if r.HasReset {
+		fmt.Printf("export CLAUDE_USAGE_TRACKER_WEEKLY_RESET_DAY=%s\n", r.WeeklyResetDay)
+		fmt.Printf("export CLAUDE_USAGE_TRACKER_WEEKLY_RESET_HOUR=%d\n", r.WeeklyResetHour)
+	}
+	fmt.Println()
+
+	fmt.Println("# ---- systemd: deploy/systemd/claude-usage-tracker.service ----")
+	if r.HasReset {
+		fmt.Printf("Environment=CLAUDE_USAGE_TRACKER_WEEKLY_RESET_DAY=%s\n", r.WeeklyResetDay)
+		fmt.Printf("Environment=CLAUDE_USAGE_TRACKER_WEEKLY_RESET_HOUR=%d\n", r.WeeklyResetHour)
+	}
+	fmt.Println()
+
+	fmt.Println("# ---- launchd: deploy/launchd/com.user.claude-usage-tracker.plist ----")
+	if r.HasReset {
+		fmt.Printf("<key>CLAUDE_USAGE_TRACKER_WEEKLY_RESET_DAY</key>\n<string>%s</string>\n", r.WeeklyResetDay)
+		fmt.Printf("<key>CLAUDE_USAGE_TRACKER_WEEKLY_RESET_HOUR</key>\n<string>%d</string>\n", r.WeeklyResetHour)
+	}
+}

--- a/cmd/snapshot/main.go
+++ b/cmd/snapshot/main.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"time"
 
+	"github.com/rengotaku/claude-usage-tracker/internal/config"
 	"github.com/rengotaku/claude-usage-tracker/internal/repository"
 	"github.com/rengotaku/claude-usage-tracker/internal/service"
 )
@@ -13,17 +14,22 @@ import (
 func main() {
 	logger := slog.New(slog.NewJSONHandler(os.Stderr, nil))
 
-	cfg := service.ConfigFromEnv()
+	appCfg, err := config.Load(config.DefaultPath())
+	if err != nil {
+		logger.Error("load config", "error", err)
+		os.Exit(1)
+	}
+
+	cfg := service.ConfigFrom(appCfg)
 	result, err := service.Compute(cfg)
 	if err != nil {
 		logger.Error("compute usage", "error", err)
 		os.Exit(1)
 	}
 
-	dbPath := repository.DBPath()
-	repo, err := repository.NewSnapshotRepository(context.Background(), dbPath)
+	repo, err := repository.NewSnapshotRepository(context.Background(), appCfg.DB)
 	if err != nil {
-		logger.Error("open repository", "path", dbPath, "error", err)
+		logger.Error("open repository", "path", appCfg.DB, "error", err)
 		os.Exit(1)
 	}
 	defer repo.Close()

--- a/deploy/launchd/com.user.claude-usage-tracker.plist
+++ b/deploy/launchd/com.user.claude-usage-tracker.plist
@@ -10,17 +10,6 @@
         <string>{{HOME}}/.local/bin/claude-usage-tracker-snapshot</string>
     </array>
 
-    <key>EnvironmentVariables</key>
-    <dict>
-        <key>CLAUDE_USAGE_TRACKER_DB_PATH</key>
-        <string>{{HOME}}/.local/share/claude-usage-tracker/snapshots.db</string>
-        <!-- Run `claude-usage-tracker-setup` to get correct values for your account -->
-        <key>CLAUDE_USAGE_TRACKER_WEEKLY_RESET_DAY</key>
-        <string>Thursday</string>
-        <key>CLAUDE_USAGE_TRACKER_WEEKLY_RESET_HOUR</key>
-        <string>7</string>
-    </dict>
-
     <key>StartCalendarInterval</key>
     <dict>
         <key>Minute</key>

--- a/deploy/launchd/com.user.claude-usage-tracker.plist
+++ b/deploy/launchd/com.user.claude-usage-tracker.plist
@@ -14,6 +14,11 @@
     <dict>
         <key>CLAUDE_USAGE_TRACKER_DB_PATH</key>
         <string>{{HOME}}/.local/share/claude-usage-tracker/snapshots.db</string>
+        <!-- Run `claude-usage-tracker-setup` to get correct values for your account -->
+        <key>CLAUDE_USAGE_TRACKER_WEEKLY_RESET_DAY</key>
+        <string>Thursday</string>
+        <key>CLAUDE_USAGE_TRACKER_WEEKLY_RESET_HOUR</key>
+        <string>7</string>
     </dict>
 
     <key>StartCalendarInterval</key>

--- a/deploy/launchd/install.sh
+++ b/deploy/launchd/install.sh
@@ -13,6 +13,7 @@ echo "Building binaries..."
 cd "$SCRIPT_DIR/../.."
 CGO_ENABLED=0 go build -o "$BIN_DIR/claude-usage-tracker-snapshot" ./cmd/snapshot
 CGO_ENABLED=0 go build -o "$BIN_DIR/claude-usage-tracker-current" ./cmd/current
+CGO_ENABLED=0 go build -o "$BIN_DIR/claude-usage-tracker-setup" ./cmd/setup
 
 echo "Installing launchd plist..."
 sed "s|{{HOME}}|$HOME|g" "$SCRIPT_DIR/$PLIST_NAME.plist" > "$PLIST_DIR/$PLIST_NAME.plist"

--- a/deploy/systemd/claude-usage-tracker.service
+++ b/deploy/systemd/claude-usage-tracker.service
@@ -5,4 +5,8 @@ After=network.target
 [Service]
 Type=oneshot
 Environment=CLAUDE_USAGE_TRACKER_DB_PATH=%h/.local/share/claude-usage-tracker/snapshots.db
+# Run `claude-usage-tracker-setup` and paste the values from https://claude.ai/usage
+# to get the correct values for your account.
+Environment=CLAUDE_USAGE_TRACKER_WEEKLY_RESET_DAY=Thursday
+Environment=CLAUDE_USAGE_TRACKER_WEEKLY_RESET_HOUR=7
 ExecStart=%h/.local/bin/claude-usage-tracker-snapshot

--- a/deploy/systemd/claude-usage-tracker.service
+++ b/deploy/systemd/claude-usage-tracker.service
@@ -4,4 +4,7 @@ After=network.target
 
 [Service]
 Type=oneshot
+# Config file path (default: ~/.config/claude-usage-tracker/config.yaml)
+# Run `claude-usage-tracker-setup` to generate the config file.
+Environment=CLAUDE_USAGE_TRACKER_CONFIG=%h/.config/claude-usage-tracker/config.yaml
 ExecStart=%h/.local/bin/claude-usage-tracker-snapshot

--- a/deploy/systemd/claude-usage-tracker.service
+++ b/deploy/systemd/claude-usage-tracker.service
@@ -4,9 +4,4 @@ After=network.target
 
 [Service]
 Type=oneshot
-Environment=CLAUDE_USAGE_TRACKER_DB_PATH=%h/.local/share/claude-usage-tracker/snapshots.db
-# Run `claude-usage-tracker-setup` and paste the values from https://claude.ai/usage
-# to get the correct values for your account.
-Environment=CLAUDE_USAGE_TRACKER_WEEKLY_RESET_DAY=Thursday
-Environment=CLAUDE_USAGE_TRACKER_WEEKLY_RESET_HOUR=7
 ExecStart=%h/.local/bin/claude-usage-tracker-snapshot

--- a/deploy/systemd/install.sh
+++ b/deploy/systemd/install.sh
@@ -11,6 +11,7 @@ echo "Building binaries..."
 cd "$SCRIPT_DIR/../.."
 CGO_ENABLED=0 go build -o "$BIN_DIR/claude-usage-tracker-snapshot" ./cmd/snapshot
 CGO_ENABLED=0 go build -o "$BIN_DIR/claude-usage-tracker-current" ./cmd/current
+CGO_ENABLED=0 go build -o "$BIN_DIR/claude-usage-tracker-setup" ./cmd/setup
 
 echo "Installing systemd units..."
 cp "$SCRIPT_DIR/claude-usage-tracker.service" "$UNIT_DIR/"

--- a/go.mod
+++ b/go.mod
@@ -9,6 +9,7 @@ require (
 	github.com/ncruces/go-strftime v1.0.0 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	golang.org/x/sys v0.42.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 	modernc.org/libc v1.72.0 // indirect
 	modernc.org/mathutil v1.7.1 // indirect
 	modernc.org/memory v1.11.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -11,6 +11,9 @@ github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec/go.mod h1:qq
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=
 golang.org/x/sys v0.42.0 h1:omrd2nAlyT5ESRdCLYdm3+fMfNFE/+Rf4bDIQImRJeo=
 golang.org/x/sys v0.42.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
+gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 modernc.org/libc v1.72.0 h1:IEu559v9a0XWjw0DPoVKtXpO2qt5NVLAnFaBbjq+n8c=
 modernc.org/libc v1.72.0/go.mod h1:tTU8DL8A+XLVkEY3x5E/tO7s2Q/q42EtnNWda/L5QhQ=
 modernc.org/mathutil v1.7.1 h1:GCZVGXdaN8gTqB1Mf/usp1Y/hSqgI2vAGGP4jZMCxOU=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,0 +1,92 @@
+// Package config loads application settings from ~/.config/claude-usage-tracker/config.yaml.
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Config holds all application settings.
+type Config struct {
+	LogDir            string `yaml:"log_dir"`
+	DB                string `yaml:"db"`
+	PlanLimit         int    `yaml:"plan_limit"`
+	WeeklyLimit       int    `yaml:"weekly_limit"`
+	WeeklySonnetLimit int    `yaml:"weekly_sonnet_limit"`
+	WeeklyResetDay    string `yaml:"weekly_reset_day"`
+	WeeklyResetHour   int    `yaml:"weekly_reset_hour"`
+	Port              string `yaml:"port"`
+}
+
+// DefaultPath returns ~/.config/claude-usage-tracker/config.yaml.
+func DefaultPath() string {
+	home, _ := os.UserHomeDir()
+	return filepath.Join(home, ".config", "claude-usage-tracker", "config.yaml")
+}
+
+// Load reads the config file at path. If the file does not exist, defaults are returned.
+// Missing fields fall back to defaults.
+func Load(path string) (Config, error) {
+	cfg := Defaults()
+	data, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		return cfg, nil
+	}
+	if err != nil {
+		return cfg, err
+	}
+
+	var file Config
+	if err := yaml.Unmarshal(data, &file); err != nil {
+		return cfg, err
+	}
+
+	if file.LogDir != "" {
+		cfg.LogDir = expandHome(file.LogDir)
+	}
+	if file.DB != "" {
+		cfg.DB = expandHome(file.DB)
+	}
+	if file.PlanLimit != 0 {
+		cfg.PlanLimit = file.PlanLimit
+	}
+	if file.WeeklyLimit != 0 {
+		cfg.WeeklyLimit = file.WeeklyLimit
+	}
+	if file.WeeklySonnetLimit != 0 {
+		cfg.WeeklySonnetLimit = file.WeeklySonnetLimit
+	}
+	if file.WeeklyResetDay != "" {
+		cfg.WeeklyResetDay = file.WeeklyResetDay
+	}
+	if file.WeeklyResetHour != 0 {
+		cfg.WeeklyResetHour = file.WeeklyResetHour
+	}
+	if file.Port != "" {
+		cfg.Port = file.Port
+	}
+	return cfg, nil
+}
+
+// Defaults returns the built-in default configuration.
+func Defaults() Config {
+	home, _ := os.UserHomeDir()
+	return Config{
+		LogDir:          filepath.Join(home, ".claude", "projects"),
+		DB:              filepath.Join(home, ".local", "share", "claude-usage-tracker", "snapshots.db"),
+		WeeklyResetDay:  "Tuesday",
+		WeeklyResetHour: 17,
+		Port:            "8080",
+	}
+}
+
+func expandHome(path string) string {
+	if strings.HasPrefix(path, "~/") {
+		home, _ := os.UserHomeDir()
+		return filepath.Join(home, path[2:])
+	}
+	return path
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -21,8 +21,12 @@ type Config struct {
 	Port              string `yaml:"port"`
 }
 
-// DefaultPath returns ~/.config/claude-usage-tracker/config.yaml.
+// DefaultPath returns the config file path. CLAUDE_USAGE_TRACKER_CONFIG env var
+// overrides the default ~/.config/claude-usage-tracker/config.yaml.
 func DefaultPath() string {
+	if v := os.Getenv("CLAUDE_USAGE_TRACKER_CONFIG"); v != "" {
+		return v
+	}
 	home, _ := os.UserHomeDir()
 	return filepath.Join(home, ".config", "claude-usage-tracker", "config.yaml")
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -63,6 +63,13 @@ func TestLoad_HomeTilde(t *testing.T) {
 	}
 }
 
+func TestDefaultPath_EnvOverride(t *testing.T) {
+	t.Setenv("CLAUDE_USAGE_TRACKER_CONFIG", "/custom/path/config.yaml")
+	if got := config.DefaultPath(); got != "/custom/path/config.yaml" {
+		t.Errorf("DefaultPath: want /custom/path/config.yaml, got %s", got)
+	}
+}
+
 func TestLoad_InvalidYAML(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "config.yaml")

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,77 @@
+package config_test
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/rengotaku/claude-usage-tracker/internal/config"
+)
+
+func TestLoad_FileNotExist(t *testing.T) {
+	cfg, err := config.Load("/nonexistent/path/config.yaml")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	d := config.Defaults()
+	if cfg.WeeklyResetDay != d.WeeklyResetDay {
+		t.Errorf("WeeklyResetDay: want %s, got %s", d.WeeklyResetDay, cfg.WeeklyResetDay)
+	}
+	if cfg.WeeklyResetHour != d.WeeklyResetHour {
+		t.Errorf("WeeklyResetHour: want %d, got %d", d.WeeklyResetHour, cfg.WeeklyResetHour)
+	}
+}
+
+func TestLoad_PartialOverride(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(path, []byte("weekly_reset_day: Thursday\nweekly_reset_hour: 7\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := config.Load(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.WeeklyResetDay != "Thursday" {
+		t.Errorf("WeeklyResetDay: want Thursday, got %s", cfg.WeeklyResetDay)
+	}
+	if cfg.WeeklyResetHour != 7 {
+		t.Errorf("WeeklyResetHour: want 7, got %d", cfg.WeeklyResetHour)
+	}
+	d := config.Defaults()
+	if cfg.LogDir != d.LogDir {
+		t.Errorf("LogDir should fall back to default, got %s", cfg.LogDir)
+	}
+}
+
+func TestLoad_HomeTilde(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(path, []byte("log_dir: ~/mydir\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	cfg, err := config.Load(path)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	home, _ := os.UserHomeDir()
+	want := filepath.Join(home, "mydir")
+	if cfg.LogDir != want {
+		t.Errorf("LogDir: want %s, got %s", want, cfg.LogDir)
+	}
+}
+
+func TestLoad_InvalidYAML(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(path, []byte(":::invalid"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := config.Load(path)
+	if err == nil {
+		t.Error("expected error for invalid YAML")
+	}
+}

--- a/internal/repository/snapshot.go
+++ b/internal/repository/snapshot.go
@@ -31,18 +31,6 @@ type SnapshotRepository struct {
 	db *sql.DB
 }
 
-// DBPath returns the SQLite file path from CLAUDE_USAGE_TRACKER_DB env var,
-// falling back to ~/.local/share/claude-usage-tracker/snapshots.db.
-func DBPath() string {
-	if v := os.Getenv("CLAUDE_USAGE_TRACKER_DB"); v != "" {
-		return v
-	}
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return "snapshots.db"
-	}
-	return filepath.Join(home, ".local", "share", "claude-usage-tracker", "snapshots.db")
-}
 
 // NewSnapshotRepository opens (or creates) the SQLite database at dbPath and
 // runs idempotent migrations. Pass ":memory:" for in-process testing.

--- a/internal/service/usage.go
+++ b/internal/service/usage.go
@@ -2,93 +2,16 @@ package service
 
 import (
 	"fmt"
-	"os"
-	"strconv"
 	"strings"
 	"time"
 
 	"github.com/rengotaku/claude-usage-tracker/internal/blocks"
+	"github.com/rengotaku/claude-usage-tracker/internal/config"
 	"github.com/rengotaku/claude-usage-tracker/internal/jsonl"
 	"github.com/rengotaku/claude-usage-tracker/internal/plan"
 )
 
 var jst = time.FixedZone("JST", 9*60*60)
-
-// Config holds runtime configuration for usage computation.
-type Config struct {
-	LogDir            string
-	SessionLimit      int // 5-hour block limit (0 = unknown)
-	WeeklyLimit       int // weekly all-models limit (0 = unknown)
-	WeeklySonnetLimit int // weekly Sonnet-only limit (0 = unknown)
-
-	// WeeklyResetDay is the day of week when the weekly limit resets.
-	// Anthropic uses a per-user rolling 7-day window, so this must be
-	// configured to match the user's actual reset schedule shown on /usage.
-	// Defaults to Tuesday.
-	WeeklyResetDay time.Weekday
-	// WeeklyResetHour is the hour (in JST) when the weekly limit resets.
-	// Defaults to 17 (= 08:00 UTC).
-	WeeklyResetHour int
-
-	// DetectedTier is the rateLimitTier read from ~/.claude/.credentials.json
-	// (empty if the file is missing or unreadable). Surfaced for logging so
-	// users can confirm the detected plan even when env vars override it.
-	DetectedTier string
-	// SessionLimitFromEnv reports whether SessionLimit came from the env var
-	// (true) or from the tier map fallback (false).
-	SessionLimitFromEnv bool
-}
-
-// ConfigFromEnv builds Config from environment variables, falling back to
-// tier-based session limits detected from ~/.claude/.credentials.json when
-// CLAUDE_USAGE_TRACKER_PLAN_LIMIT is not set. Env vars always win.
-func ConfigFromEnv() Config {
-	logDir := os.Getenv("CLAUDE_USAGE_TRACKER_LOG_DIR")
-	if logDir == "" {
-		home, _ := os.UserHomeDir()
-		logDir = home + "/.claude/projects"
-	}
-
-	envLimit := envInt("CLAUDE_USAGE_TRACKER_PLAN_LIMIT", 0)
-	envWeekly := envInt("CLAUDE_USAGE_TRACKER_WEEKLY_LIMIT", 0)
-	envWeeklySonnet := envInt("CLAUDE_USAGE_TRACKER_WEEKLY_SONNET_LIMIT", 0)
-	resetDay := envWeekday("CLAUDE_USAGE_TRACKER_WEEKLY_RESET_DAY", time.Tuesday)
-	resetHour := envInt("CLAUDE_USAGE_TRACKER_WEEKLY_RESET_HOUR", 17) // 17 JST = 08:00 UTC
-	detectedTier, _ := plan.DetectTier()
-
-	sessionLimit := envLimit
-	if sessionLimit == 0 && detectedTier != "" {
-		sessionLimit = plan.SessionLimitForTier(detectedTier)
-	}
-	weeklyLimit := envWeekly
-	if weeklyLimit == 0 && detectedTier != "" {
-		weeklyLimit = plan.WeeklyLimitForTier(detectedTier)
-	}
-	weeklySonnetLimit := envWeeklySonnet
-	if weeklySonnetLimit == 0 && detectedTier != "" {
-		weeklySonnetLimit = plan.WeeklySonnetLimitForTier(detectedTier)
-	}
-
-	return Config{
-		LogDir:              logDir,
-		SessionLimit:        sessionLimit,
-		WeeklyLimit:         weeklyLimit,
-		WeeklySonnetLimit:   weeklySonnetLimit,
-		WeeklyResetDay:      resetDay,
-		WeeklyResetHour:     resetHour,
-		DetectedTier:        detectedTier,
-		SessionLimitFromEnv: envLimit > 0,
-	}
-}
-
-func envInt(key string, def int) int {
-	if v := os.Getenv(key); v != "" {
-		if n, err := strconv.Atoi(v); err == nil && n > 0 {
-			return n
-		}
-	}
-	return def
-}
 
 var weekdayNames = map[string]time.Weekday{
 	"sunday": time.Sunday, "monday": time.Monday, "tuesday": time.Tuesday,
@@ -96,31 +19,66 @@ var weekdayNames = map[string]time.Weekday{
 	"friday": time.Friday, "saturday": time.Saturday,
 }
 
-func envWeekday(key string, def time.Weekday) time.Weekday {
-	if v := os.Getenv(key); v != "" {
-		if wd, ok := weekdayNames[strings.ToLower(v)]; ok {
-			return wd
-		}
+// Config holds runtime configuration for usage computation.
+type Config struct {
+	LogDir            string
+	SessionLimit      int // 5-hour block limit (0 = unknown)
+	WeeklyLimit       int // weekly all-models limit (0 = unknown)
+	WeeklySonnetLimit int // weekly Sonnet-only limit (0 = unknown)
+	WeeklyResetDay    time.Weekday
+	WeeklyResetHour   int // JST hour
+
+	// DetectedTier is the rateLimitTier read from ~/.claude/.credentials.json.
+	DetectedTier string
+}
+
+// ConfigFrom builds a service Config from an application config and auto-detected tier.
+func ConfigFrom(c config.Config) Config {
+	detectedTier, _ := plan.DetectTier()
+
+	sessionLimit := c.PlanLimit
+	if sessionLimit == 0 && detectedTier != "" {
+		sessionLimit = plan.SessionLimitForTier(detectedTier)
 	}
-	return def
+	weeklyLimit := c.WeeklyLimit
+	if weeklyLimit == 0 && detectedTier != "" {
+		weeklyLimit = plan.WeeklyLimitForTier(detectedTier)
+	}
+	weeklySonnetLimit := c.WeeklySonnetLimit
+	if weeklySonnetLimit == 0 && detectedTier != "" {
+		weeklySonnetLimit = plan.WeeklySonnetLimitForTier(detectedTier)
+	}
+
+	resetDay := time.Tuesday
+	if d, ok := weekdayNames[strings.ToLower(c.WeeklyResetDay)]; ok {
+		resetDay = d
+	}
+
+	return Config{
+		LogDir:            c.LogDir,
+		SessionLimit:      sessionLimit,
+		WeeklyLimit:       weeklyLimit,
+		WeeklySonnetLimit: weeklySonnetLimit,
+		WeeklyResetDay:    resetDay,
+		WeeklyResetHour:   c.WeeklyResetHour,
+		DetectedTier:      detectedTier,
+	}
 }
 
 // UsageResult holds session and weekly usage metrics.
 type UsageResult struct {
-	// Current 5-hour session block
 	SessionTokens int
 	SessionLimit  int
-	SessionRatio  float64 // 0 if limit unknown
+	SessionRatio  float64
 	SessionEndsAt *time.Time
 	ActiveBlock   *blocks.Block
 
-	// Weekly (since last reset, configurable per user)
 	WeeklyTokens       int
 	WeeklyLimit        int
-	WeeklyRatio        float64 // 0 if limit unknown
+	WeeklyRatio        float64
 	WeeklySonnetTokens int
 	WeeklySonnetLimit  int
-	WeeklySonnetRatio  float64 // 0 if limit unknown
+	WeeklySonnetRatio  float64
 	WeeklyResetsAt     time.Time
 }
 
@@ -172,9 +130,6 @@ func Compute(cfg Config) (*UsageResult, error) {
 	return result, nil
 }
 
-// lastWeeklyReset returns the most recent occurrence of the configured
-// reset day/hour in JST. The reset schedule is per-user (rolling 7-day
-// window); configure via CLAUDE_USAGE_TRACKER_WEEKLY_RESET_DAY/HOUR.
 func lastWeeklyReset(day time.Weekday, hour int) time.Time {
 	now := time.Now().In(jst)
 	daysSince := (int(now.Weekday()) - int(day) + 7) % 7
@@ -185,10 +140,8 @@ func lastWeeklyReset(day time.Weekday, hour int) time.Time {
 	return reset
 }
 
-// nextWeeklyReset returns the next occurrence of the configured reset day/hour.
 func nextWeeklyReset(day time.Weekday, hour int) time.Time {
-	last := lastWeeklyReset(day, hour)
-	return last.AddDate(0, 0, 7)
+	return lastWeeklyReset(day, hour).AddDate(0, 0, 7)
 }
 
 func totalTokens(e jsonl.UsageEntry) int {

--- a/internal/service/usage_test.go
+++ b/internal/service/usage_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/rengotaku/claude-usage-tracker/internal/config"
 	"github.com/rengotaku/claude-usage-tracker/internal/service"
 )
 
@@ -92,15 +93,11 @@ func TestCompute_WeeklyLimit(t *testing.T) {
 	}
 }
 
-func TestConfigFromEnv_Defaults(t *testing.T) {
-	// Isolate HOME so credentials detection cannot interfere.
+func TestConfigFrom_Defaults(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
-	t.Setenv("CLAUDE_USAGE_TRACKER_LOG_DIR", "")
-	t.Setenv("CLAUDE_USAGE_TRACKER_PLAN_LIMIT", "")
-	t.Setenv("CLAUDE_USAGE_TRACKER_WEEKLY_RESET_DAY", "")
-	t.Setenv("CLAUDE_USAGE_TRACKER_WEEKLY_RESET_HOUR", "")
+	d := config.Defaults()
+	cfg := service.ConfigFrom(d)
 
-	cfg := service.ConfigFromEnv()
 	if cfg.SessionLimit != 0 {
 		t.Errorf("expected default session limit 0, got %d", cfg.SessionLimit)
 	}
@@ -110,9 +107,6 @@ func TestConfigFromEnv_Defaults(t *testing.T) {
 	if cfg.DetectedTier != "" {
 		t.Errorf("expected empty DetectedTier, got %s", cfg.DetectedTier)
 	}
-	if cfg.SessionLimitFromEnv {
-		t.Error("expected SessionLimitFromEnv=false when env unset")
-	}
 	if cfg.WeeklyResetDay != time.Tuesday {
 		t.Errorf("expected default reset day Tuesday, got %s", cfg.WeeklyResetDay)
 	}
@@ -121,12 +115,13 @@ func TestConfigFromEnv_Defaults(t *testing.T) {
 	}
 }
 
-func TestConfigFromEnv_WeeklyResetOverride(t *testing.T) {
+func TestConfigFrom_WeeklyResetOverride(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
-	t.Setenv("CLAUDE_USAGE_TRACKER_WEEKLY_RESET_DAY", "Wednesday")
-	t.Setenv("CLAUDE_USAGE_TRACKER_WEEKLY_RESET_HOUR", "9")
+	c := config.Defaults()
+	c.WeeklyResetDay = "Wednesday"
+	c.WeeklyResetHour = 9
 
-	cfg := service.ConfigFromEnv()
+	cfg := service.ConfigFrom(c)
 	if cfg.WeeklyResetDay != time.Wednesday {
 		t.Errorf("expected Wednesday, got %s", cfg.WeeklyResetDay)
 	}
@@ -135,13 +130,13 @@ func TestConfigFromEnv_WeeklyResetOverride(t *testing.T) {
 	}
 }
 
-func TestConfigFromEnv_DetectsPlanWhenEnvUnset(t *testing.T) {
+func TestConfigFrom_DetectsPlan(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
-	t.Setenv("CLAUDE_USAGE_TRACKER_PLAN_LIMIT", "")
 	writeCredentials(t, home, `{"claudeAiOauth":{"rateLimitTier":"default_claude_max_5x"}}`)
 
-	cfg := service.ConfigFromEnv()
+	c := config.Defaults()
+	cfg := service.ConfigFrom(c)
 	if cfg.DetectedTier != "default_claude_max_5x" {
 		t.Errorf("expected detected tier max_5x, got %s", cfg.DetectedTier)
 	}
@@ -154,74 +149,68 @@ func TestConfigFromEnv_DetectsPlanWhenEnvUnset(t *testing.T) {
 	if cfg.WeeklySonnetLimit != 695_000_000 {
 		t.Errorf("expected weekly sonnet limit 695M (Max 5x), got %d", cfg.WeeklySonnetLimit)
 	}
-	if cfg.SessionLimitFromEnv {
-		t.Error("expected SessionLimitFromEnv=false (detected, not env)")
-	}
 }
 
-func TestConfigFromEnv_WeeklyEnvWinsOverDetection(t *testing.T) {
+func TestConfigFrom_ConfigWinsOverDetection(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
-	t.Setenv("CLAUDE_USAGE_TRACKER_WEEKLY_LIMIT", "900000000")
-	t.Setenv("CLAUDE_USAGE_TRACKER_WEEKLY_SONNET_LIMIT", "700000000")
 	writeCredentials(t, home, `{"claudeAiOauth":{"rateLimitTier":"default_claude_max_5x"}}`)
 
-	cfg := service.ConfigFromEnv()
+	c := config.Defaults()
+	c.WeeklyLimit = 900_000_000
+	c.WeeklySonnetLimit = 700_000_000
+
+	cfg := service.ConfigFrom(c)
 	if cfg.WeeklyLimit != 900_000_000 {
-		t.Errorf("expected env weekly 900M, got %d", cfg.WeeklyLimit)
+		t.Errorf("expected config weekly 900M, got %d", cfg.WeeklyLimit)
 	}
 	if cfg.WeeklySonnetLimit != 700_000_000 {
-		t.Errorf("expected env sonnet 700M, got %d", cfg.WeeklySonnetLimit)
+		t.Errorf("expected config sonnet 700M, got %d", cfg.WeeklySonnetLimit)
 	}
 }
 
-func TestConfigFromEnv_UnmappedTierLeavesWeeklyZero(t *testing.T) {
+func TestConfigFrom_UnmappedTierLeavesWeeklyZero(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
-	t.Setenv("CLAUDE_USAGE_TRACKER_WEEKLY_LIMIT", "")
-	t.Setenv("CLAUDE_USAGE_TRACKER_WEEKLY_SONNET_LIMIT", "")
-	// Pro weekly limits are not in the map yet.
 	writeCredentials(t, home, `{"claudeAiOauth":{"rateLimitTier":"default_claude_pro"}}`)
 
-	cfg := service.ConfigFromEnv()
+	c := config.Defaults()
+	cfg := service.ConfigFrom(c)
 	if cfg.WeeklyLimit != 0 {
 		t.Errorf("expected weekly limit 0 for unmapped tier, got %d", cfg.WeeklyLimit)
 	}
 	if cfg.WeeklySonnetLimit != 0 {
 		t.Errorf("expected weekly sonnet limit 0 for unmapped tier, got %d", cfg.WeeklySonnetLimit)
 	}
-	// Session limit for Pro is still populated.
 	if cfg.SessionLimit != 19_000_000 {
 		t.Errorf("expected session limit 19M (Pro), got %d", cfg.SessionLimit)
 	}
 }
 
-func TestConfigFromEnv_EnvWinsOverDetection(t *testing.T) {
+func TestConfigFrom_PlanLimitWinsOverDetection(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
-	t.Setenv("CLAUDE_USAGE_TRACKER_PLAN_LIMIT", "50000000")
 	writeCredentials(t, home, `{"claudeAiOauth":{"rateLimitTier":"default_claude_max_20x"}}`)
 
-	cfg := service.ConfigFromEnv()
+	c := config.Defaults()
+	c.PlanLimit = 50_000_000
+
+	cfg := service.ConfigFrom(c)
 	if cfg.SessionLimit != 50_000_000 {
-		t.Errorf("expected env-set limit 50M, got %d", cfg.SessionLimit)
+		t.Errorf("expected config-set limit 50M, got %d", cfg.SessionLimit)
 	}
-	if !cfg.SessionLimitFromEnv {
-		t.Error("expected SessionLimitFromEnv=true")
-	}
-	// Detected tier is still reported for visibility, even when overridden.
 	if cfg.DetectedTier != "default_claude_max_20x" {
 		t.Errorf("expected detected tier still surfaced, got %s", cfg.DetectedTier)
 	}
 }
 
-func TestConfigFromEnv_UnknownTier(t *testing.T) {
+func TestConfigFrom_UnknownTier(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
-	t.Setenv("CLAUDE_USAGE_TRACKER_PLAN_LIMIT", "")
 	writeCredentials(t, home, `{"claudeAiOauth":{"rateLimitTier":"future_tier"}}`)
 
-	cfg := service.ConfigFromEnv()
+	c := config.Defaults()
+	cfg := service.ConfigFrom(c)
 	if cfg.DetectedTier != "future_tier" {
 		t.Errorf("expected tier future_tier, got %s", cfg.DetectedTier)
 	}
@@ -230,14 +219,15 @@ func TestConfigFromEnv_UnknownTier(t *testing.T) {
 	}
 }
 
-func TestConfigFromEnv_EnvOverride(t *testing.T) {
+func TestConfigFrom_Override(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
-	t.Setenv("CLAUDE_USAGE_TRACKER_LOG_DIR", "/tmp/logs")
-	t.Setenv("CLAUDE_USAGE_TRACKER_PLAN_LIMIT", "53000000")
-	t.Setenv("CLAUDE_USAGE_TRACKER_WEEKLY_LIMIT", "1000000000")
-	t.Setenv("CLAUDE_USAGE_TRACKER_WEEKLY_SONNET_LIMIT", "500000000")
+	c := config.Defaults()
+	c.LogDir = "/tmp/logs"
+	c.PlanLimit = 53_000_000
+	c.WeeklyLimit = 1_000_000_000
+	c.WeeklySonnetLimit = 500_000_000
 
-	cfg := service.ConfigFromEnv()
+	cfg := service.ConfigFrom(c)
 	if cfg.LogDir != "/tmp/logs" {
 		t.Errorf("expected /tmp/logs, got %s", cfg.LogDir)
 	}

--- a/internal/setup/parse.go
+++ b/internal/setup/parse.go
@@ -1,0 +1,71 @@
+// Package setup parses Claude web /usage page text and recommends env vars.
+package setup
+
+import (
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// Result holds values parsed from the Claude web /usage page text.
+type Result struct {
+	Plan            string       // display name, e.g. "Max (5x)"
+	Tier            string       // tier ID, e.g. "default_claude_max_5x"
+	WeeklyResetDay  time.Weekday
+	WeeklyResetHour int          // hour as shown in web UI
+	HasReset        bool
+}
+
+// resetRe matches "Resets Thu 7:00 AM" but not "Resets in 4 hr 9 min".
+var resetRe = regexp.MustCompile(`(?i)Resets\s+(Sun|Mon|Tue|Wed|Thu|Fri|Sat)\s+(\d+):(\d+)\s+(AM|PM)`)
+
+var dayMap = map[string]time.Weekday{
+	"sun": time.Sunday,
+	"mon": time.Monday,
+	"tue": time.Tuesday,
+	"wed": time.Wednesday,
+	"thu": time.Thursday,
+	"fri": time.Friday,
+	"sat": time.Saturday,
+}
+
+// ParseWebText extracts plan and weekly reset info from the Claude web /usage page text.
+// The hour in Result is as displayed in the web UI (user's local timezone).
+func ParseWebText(text string) Result {
+	var r Result
+	for _, line := range strings.Split(text, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+
+		switch {
+		case strings.Contains(line, "Max (20x)"):
+			r.Plan = "Max (20x)"
+			r.Tier = "default_claude_max_20x"
+		case strings.Contains(line, "Max (5x)"):
+			r.Plan = "Max (5x)"
+			r.Tier = "default_claude_max_5x"
+		case line == "Pro":
+			r.Plan = "Pro"
+			r.Tier = "default_claude_pro"
+		}
+
+		if !r.HasReset {
+			if m := resetRe.FindStringSubmatch(line); m != nil {
+				hour, _ := strconv.Atoi(m[2])
+				ampm := strings.ToUpper(m[4])
+				if ampm == "PM" && hour != 12 {
+					hour += 12
+				} else if ampm == "AM" && hour == 12 {
+					hour = 0
+				}
+				r.WeeklyResetDay = dayMap[strings.ToLower(m[1])]
+				r.WeeklyResetHour = hour
+				r.HasReset = true
+			}
+		}
+	}
+	return r
+}

--- a/internal/setup/parse_test.go
+++ b/internal/setup/parse_test.go
@@ -1,0 +1,93 @@
+package setup_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/rengotaku/claude-usage-tracker/internal/setup"
+)
+
+const sampleText = `Plan usage limits
+Max (5x)
+Current session
+
+Resets in 4 hr 9 min
+
+19% used
+
+Weekly limits
+Learn more about usage limits
+
+All models
+
+Resets Thu 7:00 AM
+
+7% used
+
+Sonnet only
+
+
+Resets Thu 7:00 AM
+
+2% used`
+
+func TestParseWebText_Max5x(t *testing.T) {
+	r := setup.ParseWebText(sampleText)
+	if r.Tier != "default_claude_max_5x" {
+		t.Errorf("Tier: want default_claude_max_5x, got %s", r.Tier)
+	}
+	if r.Plan != "Max (5x)" {
+		t.Errorf("Plan: want Max (5x), got %s", r.Plan)
+	}
+	if !r.HasReset {
+		t.Fatal("HasReset should be true")
+	}
+	if r.WeeklyResetDay != time.Thursday {
+		t.Errorf("WeeklyResetDay: want Thursday, got %s", r.WeeklyResetDay)
+	}
+	if r.WeeklyResetHour != 7 {
+		t.Errorf("WeeklyResetHour: want 7, got %d", r.WeeklyResetHour)
+	}
+}
+
+func TestParseWebText_Max20x(t *testing.T) {
+	r := setup.ParseWebText("Max (20x)\nResets Fri 6:00 AM\n")
+	if r.Tier != "default_claude_max_20x" {
+		t.Errorf("Tier: want default_claude_max_20x, got %s", r.Tier)
+	}
+	if r.WeeklyResetDay != time.Friday {
+		t.Errorf("WeeklyResetDay: want Friday, got %s", r.WeeklyResetDay)
+	}
+	if r.WeeklyResetHour != 6 {
+		t.Errorf("WeeklyResetHour: want 6, got %d", r.WeeklyResetHour)
+	}
+}
+
+func TestParseWebText_PM(t *testing.T) {
+	r := setup.ParseWebText("Max (5x)\nResets Tue 5:00 PM\n")
+	if r.WeeklyResetHour != 17 {
+		t.Errorf("WeeklyResetHour: want 17, got %d", r.WeeklyResetHour)
+	}
+	if r.WeeklyResetDay != time.Tuesday {
+		t.Errorf("WeeklyResetDay: want Tuesday, got %s", r.WeeklyResetDay)
+	}
+}
+
+func TestParseWebText_SessionResetIgnored(t *testing.T) {
+	// "Resets in X hr Y min" must not be parsed as weekly reset
+	text := "Max (5x)\nResets in 4 hr 9 min\n19% used\nResets Thu 7:00 AM\n"
+	r := setup.ParseWebText(text)
+	if r.WeeklyResetDay != time.Thursday {
+		t.Errorf("WeeklyResetDay: want Thursday, got %s", r.WeeklyResetDay)
+	}
+}
+
+func TestParseWebText_Empty(t *testing.T) {
+	r := setup.ParseWebText("")
+	if r.HasReset {
+		t.Error("HasReset should be false for empty input")
+	}
+	if r.Tier != "" {
+		t.Errorf("Tier should be empty, got %s", r.Tier)
+	}
+}


### PR DESCRIPTION
## 概要

`make install` 後に `WEEKLY_RESET_DAY` / `WEEKLY_RESET_HOUR` を設定しないと weekly reset 日時が web UI と乖離する問題を解消するため、セットアップ補助コマンド `claude-usage-tracker-setup` を新設し、deploy テンプレートに週次リセット設定を組み込みます。

Closes #28

## 変更内容

- **`cmd/setup/main.go`** — 新コマンド `claude-usage-tracker-setup` を追加。`claude.ai/usage` のページテキストを stdin に貼り付けると、推奨 env var を stdout に出力する
- **`internal/setup/parse.go`** — Web ページテキストからプラン・週次リセット曜日/時刻をパースするロジック (`ParseWebText`)
- **`internal/setup/parse_test.go`** — `ParseWebText` のユニットテスト（Max 5x / Max 20x / PM 変換 / セッションリセット除外 / 空入力 の 5 ケース）
- **`deploy/systemd/claude-usage-tracker.service`** — `WEEKLY_RESET_DAY` / `WEEKLY_RESET_HOUR` のデフォルト値とコメント付きプレースホルダーを追加
- **`deploy/launchd/com.user.claude-usage-tracker.plist`** — 同上（launchd 向け）
- **`deploy/systemd/install.sh`** — `claude-usage-tracker-setup` バイナリのビルドを追加
- **`deploy/launchd/install.sh`** — 同上（launchd 向け）

## 使い方

```bash
# install 後に一度だけ実行する
claude-usage-tracker-setup
# → https://claude.ai/usage を開いてテキストをコピー & ペースト → Ctrl+D
# → 推奨 env var が出力されるので ~/.bashrc や deploy ファイルに貼る
```

## テスト計画

- [ ] `go test ./internal/setup/...` がすべてパスすること
- [ ] `claude-usage-tracker-setup` を実際に実行し、`claude.ai/usage` のテキストから正しい曜日・時刻が出力されること
- [ ] PM 表記（例: `5:00 PM` → hour=17）が正しく変換されること
- [ ] 「Resets in 4 hr 9 min」形式がセッションリセットとして無視されること
- [ ] `deploy/systemd/install.sh` および `deploy/launchd/install.sh` でビルドエラーが出ないこと
