### PR TITLE
refactor: ハードコードされたトークンリミットを削除し config.yaml 設定を必須化

### DIFF
--- a/cmd/current/main.go
+++ b/cmd/current/main.go
@@ -42,6 +42,10 @@ func main() {
 	}
 
 	cfg := service.ConfigFrom(appCfg)
+	if err := service.ValidateConfig(cfg); err != nil {
+		logger.Error("invalid config", "error", err)
+		os.Exit(1)
+	}
 	logPlanDetection(logger, cfg)
 	result, err := service.Compute(cfg)
 	if err != nil {

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -10,6 +10,7 @@ import (
 	"github.com/rengotaku/claude-usage-tracker/internal/config"
 	"github.com/rengotaku/claude-usage-tracker/internal/repository"
 	"github.com/rengotaku/claude-usage-tracker/internal/server"
+	"github.com/rengotaku/claude-usage-tracker/internal/service"
 )
 
 func main() {
@@ -28,6 +29,10 @@ func main() {
 	}
 	defer repo.Close()
 
+	if err := service.ValidateConfig(service.ConfigFrom(appCfg)); err != nil {
+		logger.Error("invalid config", "error", err)
+		os.Exit(1)
+	}
 	cfg := server.Config{
 		SessionLimit:      appCfg.PlanLimit,
 		WeeklyLimit:       appCfg.WeeklyLimit,

--- a/cmd/snapshot/main.go
+++ b/cmd/snapshot/main.go
@@ -21,6 +21,10 @@ func main() {
 	}
 
 	cfg := service.ConfigFrom(appCfg)
+	if err := service.ValidateConfig(cfg); err != nil {
+		logger.Error("invalid config", "error", err)
+		os.Exit(1)
+	}
 	result, err := service.Compute(cfg)
 	if err != nil {
 		logger.Error("compute usage", "error", err)

--- a/internal/plan/plan.go
+++ b/internal/plan/plan.go
@@ -1,12 +1,9 @@
-// Package plan detects the Claude subscription tier from local credentials
-// and exposes known session/weekly token limits per tier.
+// Package plan detects the Claude subscription tier from local credentials.
 //
 // The tier identifier is read from ~/.claude/.credentials.json's
-// claudeAiOauth.rateLimitTier field. Numeric limits are derived from the
-// web /usage dashboard's percentage display (Anthropic does not publish
-// exact numbers) and may drift over time; env vars in the service package
-// always take precedence. Limits are only populated for tiers whose
-// percentages have been observed; others return 0.
+// claudeAiOauth.rateLimitTier field. Token limits are not embedded here —
+// configure plan_limit / weekly_limit / weekly_sonnet_limit in
+// ~/.config/claude-usage-tracker/config.yaml instead.
 package plan
 
 import (
@@ -21,26 +18,6 @@ const (
 	TierMax5x  = "default_claude_max_5x"
 	TierMax20x = "default_claude_max_20x"
 )
-
-// sessionLimits map 5-hour session token caps.
-// Max 5x re-verified against web /usage on 2026-04-24: web showed 27% with 24.1M tokens → limit ≈ 90M.
-// Pro / Max 20x are prior community estimates, not yet re-verified.
-var sessionLimits = map[string]int{
-	TierPro:    19_000_000,
-	TierMax5x:  90_000_000,
-	TierMax20x: 220_000_000,
-}
-
-// weeklyLimits map all-models weekly token caps.
-// Only populated for tiers with /usage-confirmed values.
-var weeklyLimits = map[string]int{
-	TierMax5x: 833_000_000,
-}
-
-// weeklySonnetLimits map Sonnet-only weekly token caps.
-var weeklySonnetLimits = map[string]int{
-	TierMax5x: 695_000_000,
-}
 
 // DetectTier reads ~/.claude/.credentials.json and returns rateLimitTier.
 func DetectTier() (string, error) {
@@ -71,22 +48,4 @@ func DetectTierAt(path string) (string, error) {
 		return "", errors.New("rateLimitTier not found in credentials")
 	}
 	return creds.ClaudeAIOauth.RateLimitTier, nil
-}
-
-// SessionLimitForTier returns the 5-hour session token limit for a known
-// tier, or 0 if the tier is unknown.
-func SessionLimitForTier(tier string) int {
-	return sessionLimits[tier]
-}
-
-// WeeklyLimitForTier returns the all-models weekly token limit for a known
-// tier, or 0 if the tier is unknown / not yet measured.
-func WeeklyLimitForTier(tier string) int {
-	return weeklyLimits[tier]
-}
-
-// WeeklySonnetLimitForTier returns the Sonnet-only weekly token limit for a
-// known tier, or 0 if the tier is unknown / not yet measured.
-func WeeklySonnetLimitForTier(tier string) int {
-	return weeklySonnetLimits[tier]
 }

--- a/internal/plan/plan_test.go
+++ b/internal/plan/plan_test.go
@@ -63,62 +63,6 @@ func TestDetectTierAt_InvalidJSON(t *testing.T) {
 	}
 }
 
-func TestSessionLimitForTier(t *testing.T) {
-	tests := []struct {
-		tier string
-		want int
-	}{
-		{"default_claude_pro", 19_000_000},
-		{"default_claude_max_5x", 90_000_000},
-		{"default_claude_max_20x", 220_000_000},
-		{"unknown_tier", 0},
-		{"", 0},
-	}
-	for _, tt := range tests {
-		if got := plan.SessionLimitForTier(tt.tier); got != tt.want {
-			t.Errorf("SessionLimitForTier(%q) = %d, want %d", tt.tier, got, tt.want)
-		}
-	}
-}
-
-func TestWeeklyLimitForTier(t *testing.T) {
-	tests := []struct {
-		tier string
-		want int
-	}{
-		{"default_claude_max_5x", 833_000_000},
-		// Pro and Max 20x weekly limits are not yet confirmed from /usage
-		// web values; callers must rely on env vars for those tiers.
-		{"default_claude_pro", 0},
-		{"default_claude_max_20x", 0},
-		{"unknown_tier", 0},
-		{"", 0},
-	}
-	for _, tt := range tests {
-		if got := plan.WeeklyLimitForTier(tt.tier); got != tt.want {
-			t.Errorf("WeeklyLimitForTier(%q) = %d, want %d", tt.tier, got, tt.want)
-		}
-	}
-}
-
-func TestWeeklySonnetLimitForTier(t *testing.T) {
-	tests := []struct {
-		tier string
-		want int
-	}{
-		{"default_claude_max_5x", 695_000_000},
-		{"default_claude_pro", 0},
-		{"default_claude_max_20x", 0},
-		{"unknown_tier", 0},
-		{"", 0},
-	}
-	for _, tt := range tests {
-		if got := plan.WeeklySonnetLimitForTier(tt.tier); got != tt.want {
-			t.Errorf("WeeklySonnetLimitForTier(%q) = %d, want %d", tt.tier, got, tt.want)
-		}
-	}
-}
-
 func TestDetectTier_UsesHomeDir(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)

--- a/internal/service/usage.go
+++ b/internal/service/usage.go
@@ -22,9 +22,9 @@ var weekdayNames = map[string]time.Weekday{
 // Config holds runtime configuration for usage computation.
 type Config struct {
 	LogDir            string
-	SessionLimit      int // 5-hour block limit (0 = unknown)
-	WeeklyLimit       int // weekly all-models limit (0 = unknown)
-	WeeklySonnetLimit int // weekly Sonnet-only limit (0 = unknown)
+	SessionLimit      int // 5-hour block limit (0 = not configured)
+	WeeklyLimit       int // weekly all-models limit (0 = not configured)
+	WeeklySonnetLimit int // weekly Sonnet-only limit (0 = not configured)
 	WeeklyResetDay    time.Weekday
 	WeeklyResetHour   int // JST hour
 
@@ -32,22 +32,10 @@ type Config struct {
 	DetectedTier string
 }
 
-// ConfigFrom builds a service Config from an application config and auto-detected tier.
+// ConfigFrom builds a service Config from an application config.
+// Token limits come exclusively from the config file; no hardcoded defaults.
 func ConfigFrom(c config.Config) Config {
 	detectedTier, _ := plan.DetectTier()
-
-	sessionLimit := c.PlanLimit
-	if sessionLimit == 0 && detectedTier != "" {
-		sessionLimit = plan.SessionLimitForTier(detectedTier)
-	}
-	weeklyLimit := c.WeeklyLimit
-	if weeklyLimit == 0 && detectedTier != "" {
-		weeklyLimit = plan.WeeklyLimitForTier(detectedTier)
-	}
-	weeklySonnetLimit := c.WeeklySonnetLimit
-	if weeklySonnetLimit == 0 && detectedTier != "" {
-		weeklySonnetLimit = plan.WeeklySonnetLimitForTier(detectedTier)
-	}
 
 	resetDay := time.Tuesday
 	if d, ok := weekdayNames[strings.ToLower(c.WeeklyResetDay)]; ok {
@@ -56,13 +44,32 @@ func ConfigFrom(c config.Config) Config {
 
 	return Config{
 		LogDir:            c.LogDir,
-		SessionLimit:      sessionLimit,
-		WeeklyLimit:       weeklyLimit,
-		WeeklySonnetLimit: weeklySonnetLimit,
+		SessionLimit:      c.PlanLimit,
+		WeeklyLimit:       c.WeeklyLimit,
+		WeeklySonnetLimit: c.WeeklySonnetLimit,
 		WeeklyResetDay:    resetDay,
 		WeeklyResetHour:   c.WeeklyResetHour,
 		DetectedTier:      detectedTier,
 	}
+}
+
+// ValidateConfig returns an error if required token limits are not configured.
+func ValidateConfig(cfg Config) error {
+	var missing []string
+	if cfg.SessionLimit == 0 {
+		missing = append(missing, "plan_limit")
+	}
+	if cfg.WeeklyLimit == 0 {
+		missing = append(missing, "weekly_limit")
+	}
+	if cfg.WeeklySonnetLimit == 0 {
+		missing = append(missing, "weekly_sonnet_limit")
+	}
+	if len(missing) > 0 {
+		return fmt.Errorf("required config not set: %s — run 'claude-usage-tracker-setup' to configure",
+			strings.Join(missing, ", "))
+	}
+	return nil
 }
 
 // UsageResult holds session and weekly usage metrics.

--- a/internal/service/usage_test.go
+++ b/internal/service/usage_test.go
@@ -101,6 +101,12 @@ func TestConfigFrom_Defaults(t *testing.T) {
 	if cfg.SessionLimit != 0 {
 		t.Errorf("expected default session limit 0, got %d", cfg.SessionLimit)
 	}
+	if cfg.WeeklyLimit != 0 {
+		t.Errorf("expected default weekly limit 0, got %d", cfg.WeeklyLimit)
+	}
+	if cfg.WeeklySonnetLimit != 0 {
+		t.Errorf("expected default weekly sonnet limit 0, got %d", cfg.WeeklySonnetLimit)
+	}
 	if cfg.LogDir == "" {
 		t.Error("expected non-empty log dir")
 	}
@@ -130,7 +136,7 @@ func TestConfigFrom_WeeklyResetOverride(t *testing.T) {
 	}
 }
 
-func TestConfigFrom_DetectsPlan(t *testing.T) {
+func TestConfigFrom_TierDetected(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 	writeCredentials(t, home, `{"claudeAiOauth":{"rateLimitTier":"default_claude_max_5x"}}`)
@@ -140,82 +146,37 @@ func TestConfigFrom_DetectsPlan(t *testing.T) {
 	if cfg.DetectedTier != "default_claude_max_5x" {
 		t.Errorf("expected detected tier max_5x, got %s", cfg.DetectedTier)
 	}
-	if cfg.SessionLimit != 90_000_000 {
-		t.Errorf("expected session limit 90M (Max 5x), got %d", cfg.SessionLimit)
+	// limits come from config only — not auto-populated from tier
+	if cfg.SessionLimit != 0 {
+		t.Errorf("expected session limit 0 (not set in config), got %d", cfg.SessionLimit)
 	}
-	if cfg.WeeklyLimit != 833_000_000 {
-		t.Errorf("expected weekly limit 833M (Max 5x), got %d", cfg.WeeklyLimit)
+	if cfg.WeeklyLimit != 0 {
+		t.Errorf("expected weekly limit 0 (not set in config), got %d", cfg.WeeklyLimit)
 	}
-	if cfg.WeeklySonnetLimit != 695_000_000 {
-		t.Errorf("expected weekly sonnet limit 695M (Max 5x), got %d", cfg.WeeklySonnetLimit)
+	if cfg.WeeklySonnetLimit != 0 {
+		t.Errorf("expected weekly sonnet limit 0 (not set in config), got %d", cfg.WeeklySonnetLimit)
 	}
 }
 
-func TestConfigFrom_ConfigWinsOverDetection(t *testing.T) {
+func TestConfigFrom_ConfigLimitsUsed(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 	writeCredentials(t, home, `{"claudeAiOauth":{"rateLimitTier":"default_claude_max_5x"}}`)
 
 	c := config.Defaults()
-	c.WeeklyLimit = 900_000_000
-	c.WeeklySonnetLimit = 700_000_000
+	c.PlanLimit = 90_000_000
+	c.WeeklyLimit = 1_260_000_000
+	c.WeeklySonnetLimit = 1_300_000_000
 
 	cfg := service.ConfigFrom(c)
-	if cfg.WeeklyLimit != 900_000_000 {
-		t.Errorf("expected config weekly 900M, got %d", cfg.WeeklyLimit)
+	if cfg.SessionLimit != 90_000_000 {
+		t.Errorf("expected 90M, got %d", cfg.SessionLimit)
 	}
-	if cfg.WeeklySonnetLimit != 700_000_000 {
-		t.Errorf("expected config sonnet 700M, got %d", cfg.WeeklySonnetLimit)
+	if cfg.WeeklyLimit != 1_260_000_000 {
+		t.Errorf("expected 1260M, got %d", cfg.WeeklyLimit)
 	}
-}
-
-func TestConfigFrom_UnmappedTierLeavesWeeklyZero(t *testing.T) {
-	home := t.TempDir()
-	t.Setenv("HOME", home)
-	writeCredentials(t, home, `{"claudeAiOauth":{"rateLimitTier":"default_claude_pro"}}`)
-
-	c := config.Defaults()
-	cfg := service.ConfigFrom(c)
-	if cfg.WeeklyLimit != 0 {
-		t.Errorf("expected weekly limit 0 for unmapped tier, got %d", cfg.WeeklyLimit)
-	}
-	if cfg.WeeklySonnetLimit != 0 {
-		t.Errorf("expected weekly sonnet limit 0 for unmapped tier, got %d", cfg.WeeklySonnetLimit)
-	}
-	if cfg.SessionLimit != 19_000_000 {
-		t.Errorf("expected session limit 19M (Pro), got %d", cfg.SessionLimit)
-	}
-}
-
-func TestConfigFrom_PlanLimitWinsOverDetection(t *testing.T) {
-	home := t.TempDir()
-	t.Setenv("HOME", home)
-	writeCredentials(t, home, `{"claudeAiOauth":{"rateLimitTier":"default_claude_max_20x"}}`)
-
-	c := config.Defaults()
-	c.PlanLimit = 50_000_000
-
-	cfg := service.ConfigFrom(c)
-	if cfg.SessionLimit != 50_000_000 {
-		t.Errorf("expected config-set limit 50M, got %d", cfg.SessionLimit)
-	}
-	if cfg.DetectedTier != "default_claude_max_20x" {
-		t.Errorf("expected detected tier still surfaced, got %s", cfg.DetectedTier)
-	}
-}
-
-func TestConfigFrom_UnknownTier(t *testing.T) {
-	home := t.TempDir()
-	t.Setenv("HOME", home)
-	writeCredentials(t, home, `{"claudeAiOauth":{"rateLimitTier":"future_tier"}}`)
-
-	c := config.Defaults()
-	cfg := service.ConfigFrom(c)
-	if cfg.DetectedTier != "future_tier" {
-		t.Errorf("expected tier future_tier, got %s", cfg.DetectedTier)
-	}
-	if cfg.SessionLimit != 0 {
-		t.Errorf("expected 0 session limit for unknown tier, got %d", cfg.SessionLimit)
+	if cfg.WeeklySonnetLimit != 1_300_000_000 {
+		t.Errorf("expected 1300M, got %d", cfg.WeeklySonnetLimit)
 	}
 }
 
@@ -240,6 +201,55 @@ func TestConfigFrom_Override(t *testing.T) {
 	if cfg.WeeklySonnetLimit != 500_000_000 {
 		t.Errorf("expected 500000000, got %d", cfg.WeeklySonnetLimit)
 	}
+}
+
+func TestValidateConfig_AllSet(t *testing.T) {
+	cfg := service.Config{
+		SessionLimit:      90_000_000,
+		WeeklyLimit:       1_260_000_000,
+		WeeklySonnetLimit: 1_300_000_000,
+	}
+	if err := service.ValidateConfig(cfg); err != nil {
+		t.Errorf("expected no error, got %v", err)
+	}
+}
+
+func TestValidateConfig_MissingAll(t *testing.T) {
+	cfg := service.Config{}
+	err := service.ValidateConfig(cfg)
+	if err == nil {
+		t.Fatal("expected error for missing limits")
+	}
+	msg := err.Error()
+	for _, field := range []string{"plan_limit", "weekly_limit", "weekly_sonnet_limit"} {
+		if !contains(msg, field) {
+			t.Errorf("expected error to mention %q, got: %s", field, msg)
+		}
+	}
+}
+
+func TestValidateConfig_MissingPartial(t *testing.T) {
+	cfg := service.Config{SessionLimit: 90_000_000}
+	err := service.ValidateConfig(cfg)
+	if err == nil {
+		t.Fatal("expected error for missing weekly limits")
+	}
+	if contains(err.Error(), "plan_limit") {
+		t.Errorf("plan_limit should not be in error, got: %s", err.Error())
+	}
+}
+
+func contains(s, sub string) bool {
+	return len(s) >= len(sub) && (s == sub || len(s) > 0 && containsHelper(s, sub))
+}
+
+func containsHelper(s, sub string) bool {
+	for i := 0; i <= len(s)-len(sub); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
 }
 
 func writeCredentials(t *testing.T, home, body string) {


### PR DESCRIPTION
## 概要

Closes #30

`plan.go` にハードコードされていたトークンリミット定数（session / weekly / weekly_sonnet）を削除し、`config.yaml` の設定を必須化します。Anthropic はリミット値を公式公開しておらず、実測値と乖離するハードコード定数が使用率の誤表示を引き起こしていたための対応です。

## 変更内容

- **`internal/plan/plan.go`** — `sessionLimits` / `weeklyLimits` / `weeklySonnetLimits` マップと3つの公開関数を削除
- **`internal/service/usage.go`** — `ConfigFrom` でのティア自動補完ロジックを廃止。`ValidateConfig` 関数を追加し、`plan_limit` / `weekly_limit` / `weekly_sonnet_limit` のいずれかが 0（未設定）の場合は起動時にエラー終了させる
- **`cmd/current/main.go`, `cmd/snapshot/main.go`, `cmd/server/main.go`** — `ValidateConfig` チェックを追加
- **`internal/plan/plan_test.go`, `internal/service/usage_test.go`** — 新しい動作に合わせてテストを更新

## 移行手順

config.yaml に以下を追記してください。値は claude.ai/usage の表示 % とトークン数から逆算できます（実使用トークン数 ÷ 表示%）：

```yaml
plan_limit: 90000000
weekly_limit: 1260000000
weekly_sonnet_limit: 1300000000
```

## テスト計画

- [x] `go test ./...` が全 PASS
- [x] `plan_limit` 等が 0 のとき起動時エラーになること
- [x] 設定済み config.yaml で `cmd/current` が正しい % を表示すること（Web 表示と一致）
