### PR TITLE
feat: トークン内訳(input/output/cache)をDBに個別保存する

### DIFF
--- a/cmd/current/main.go
+++ b/cmd/current/main.go
@@ -15,12 +15,20 @@ import (
 
 var jst = time.FixedZone("JST", 9*60*60)
 
+type tokenBreakdownJSON struct {
+	Input         int `json:"input"`
+	Output        int `json:"output"`
+	CacheCreation int `json:"cache_creation"`
+	CacheRead     int `json:"cache_read"`
+}
+
 type jsonOutput struct {
 	Session struct {
-		TokensUsed int     `json:"tokens_used"`
-		Limit      int     `json:"limit,omitempty"`
-		Ratio      float64 `json:"ratio,omitempty"`
-		EndsAt     string  `json:"ends_at,omitempty"`
+		TokensUsed int                `json:"tokens_used"`
+		Breakdown  tokenBreakdownJSON `json:"breakdown"`
+		Limit      int                `json:"limit,omitempty"`
+		Ratio      float64            `json:"ratio,omitempty"`
+		EndsAt     string             `json:"ends_at,omitempty"`
 	} `json:"session"`
 	Weekly struct {
 		TokensUsed   int     `json:"tokens_used"`
@@ -86,6 +94,12 @@ func main() {
 	if jsonFlag {
 		out := jsonOutput{}
 		out.Session.TokensUsed = result.SessionTokens
+		out.Session.Breakdown = tokenBreakdownJSON{
+			Input:         result.SessionBreakdown.Input,
+			Output:        result.SessionBreakdown.Output,
+			CacheCreation: result.SessionBreakdown.CacheCreation,
+			CacheRead:     result.SessionBreakdown.CacheRead,
+		}
 		out.Session.Limit = result.SessionLimit
 		out.Session.Ratio = result.SessionRatio
 		if result.SessionEndsAt != nil {
@@ -110,6 +124,9 @@ func main() {
 
 	resetsAt := result.WeeklyResetsAt.In(jst).Format("Jan 2, 3pm")
 	fmt.Printf("Current session   %s\n", sessionLine(result))
+	b := result.SessionBreakdown
+	fmt.Printf("  input %-8s  output %-8s  cache_creation %-8s  cache_read %s\n",
+		formatM(b.Input), formatM(b.Output), formatM(b.CacheCreation), formatM(b.CacheRead))
 	fmt.Printf("Weekly (All)      %s\n", weeklyLine(result.WeeklyTokens, result.WeeklyLimit, result.WeeklyRatio, resetsAt))
 	fmt.Printf("Weekly (Sonnet)   %s\n", weeklyLine(result.WeeklySonnetTokens, result.WeeklySonnetLimit, result.WeeklySonnetRatio, resetsAt))
 }

--- a/cmd/snapshot/main.go
+++ b/cmd/snapshot/main.go
@@ -41,6 +41,7 @@ func main() {
 	snap := repository.Snapshot{
 		TakenAt:            time.Now().UTC(),
 		TokensUsed:         result.SessionTokens,
+		Tokens:             result.SessionBreakdown,
 		UsageRatio:         result.SessionRatio,
 		WeeklyTokens:       result.WeeklyTokens,
 		WeeklySonnetTokens: result.WeeklySonnetTokens,

--- a/internal/blocks/blocks.go
+++ b/internal/blocks/blocks.go
@@ -9,12 +9,26 @@ import (
 
 const blockDuration = 5 * time.Hour
 
+// TokenBreakdown holds per-type token counts for a block.
+type TokenBreakdown struct {
+	Input         int
+	Output        int
+	CacheCreation int
+	CacheRead     int
+}
+
+// Total returns the sum of all token types.
+func (t TokenBreakdown) Total() int {
+	return t.Input + t.Output + t.CacheCreation + t.CacheRead
+}
+
 // Block represents a 5-hour billing period.
 type Block struct {
 	StartTime   time.Time
 	EndTime     time.Time
 	IsActive    bool
 	TotalTokens int
+	Tokens      TokenBreakdown
 	EntryCount  int
 }
 
@@ -44,6 +58,10 @@ func Build(entries []jsonl.UsageEntry) []Block {
 			current = &blocks[len(blocks)-1]
 		}
 		current.TotalTokens += totalTokens(e)
+		current.Tokens.Input += e.InputTokens
+		current.Tokens.Output += e.OutputTokens
+		current.Tokens.CacheCreation += e.CacheCreationInputTokens
+		current.Tokens.CacheRead += e.CacheReadInputTokens
 		current.EntryCount++
 	}
 

--- a/internal/repository/snapshot.go
+++ b/internal/repository/snapshot.go
@@ -11,6 +11,8 @@ import (
 	"time"
 
 	_ "modernc.org/sqlite"
+
+	"github.com/rengotaku/claude-usage-tracker/internal/blocks"
 )
 
 const timeLayout = time.RFC3339
@@ -21,6 +23,7 @@ type Snapshot struct {
 	BlockStartedAt     time.Time
 	BlockEndedAt       *time.Time
 	TokensUsed         int
+	Tokens             blocks.TokenBreakdown
 	UsageRatio         float64
 	WeeklyTokens       int
 	WeeklySonnetTokens int
@@ -61,6 +64,10 @@ func (r *SnapshotRepository) migrate(ctx context.Context) error {
 			block_started_at      TEXT NOT NULL,
 			block_ended_at        TEXT,
 			tokens_used           INTEGER NOT NULL,
+			input_tokens          INTEGER NOT NULL DEFAULT 0,
+			output_tokens         INTEGER NOT NULL DEFAULT 0,
+			cache_creation_tokens INTEGER NOT NULL DEFAULT 0,
+			cache_read_tokens     INTEGER NOT NULL DEFAULT 0,
 			usage_ratio           REAL    NOT NULL,
 			weekly_tokens         INTEGER NOT NULL DEFAULT 0,
 			weekly_sonnet_tokens  INTEGER NOT NULL DEFAULT 0
@@ -70,10 +77,14 @@ func (r *SnapshotRepository) migrate(ctx context.Context) error {
 		return fmt.Errorf("create table: %w", err)
 	}
 
-	// Add weekly columns to existing tables (idempotent).
+	// Add columns to existing tables (idempotent).
 	for _, col := range []string{
-		"ALTER TABLE snapshots ADD COLUMN weekly_tokens        INTEGER NOT NULL DEFAULT 0",
-		"ALTER TABLE snapshots ADD COLUMN weekly_sonnet_tokens INTEGER NOT NULL DEFAULT 0",
+		"ALTER TABLE snapshots ADD COLUMN weekly_tokens         INTEGER NOT NULL DEFAULT 0",
+		"ALTER TABLE snapshots ADD COLUMN weekly_sonnet_tokens  INTEGER NOT NULL DEFAULT 0",
+		"ALTER TABLE snapshots ADD COLUMN input_tokens          INTEGER NOT NULL DEFAULT 0",
+		"ALTER TABLE snapshots ADD COLUMN output_tokens         INTEGER NOT NULL DEFAULT 0",
+		"ALTER TABLE snapshots ADD COLUMN cache_creation_tokens INTEGER NOT NULL DEFAULT 0",
+		"ALTER TABLE snapshots ADD COLUMN cache_read_tokens     INTEGER NOT NULL DEFAULT 0",
 	} {
 		if _, err := r.db.ExecContext(ctx, col); err != nil {
 			if !strings.Contains(err.Error(), "duplicate column name") {
@@ -93,12 +104,17 @@ func (r *SnapshotRepository) Save(ctx context.Context, s Snapshot) error {
 	}
 	_, err := r.db.ExecContext(ctx,
 		`INSERT OR REPLACE INTO snapshots
-			(taken_at, block_started_at, block_ended_at, tokens_used, usage_ratio, weekly_tokens, weekly_sonnet_tokens)
-		 VALUES (?, ?, ?, ?, ?, ?, ?)`,
+			(taken_at, block_started_at, block_ended_at, tokens_used, input_tokens, output_tokens,
+			 cache_creation_tokens, cache_read_tokens, usage_ratio, weekly_tokens, weekly_sonnet_tokens)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		s.TakenAt.UTC().Truncate(time.Second).Format(timeLayout),
 		s.BlockStartedAt.UTC().Truncate(time.Second).Format(timeLayout),
 		endedAt,
 		s.TokensUsed,
+		s.Tokens.Input,
+		s.Tokens.Output,
+		s.Tokens.CacheCreation,
+		s.Tokens.CacheRead,
 		s.UsageRatio,
 		s.WeeklyTokens,
 		s.WeeklySonnetTokens,
@@ -112,7 +128,9 @@ func (r *SnapshotRepository) Save(ctx context.Context, s Snapshot) error {
 // Latest returns the most recently taken Snapshot, or nil if none exists.
 func (r *SnapshotRepository) Latest(ctx context.Context) (*Snapshot, error) {
 	row := r.db.QueryRowContext(ctx,
-		`SELECT taken_at, block_started_at, block_ended_at, tokens_used, usage_ratio, weekly_tokens, weekly_sonnet_tokens
+		`SELECT taken_at, block_started_at, block_ended_at, tokens_used,
+		        input_tokens, output_tokens, cache_creation_tokens, cache_read_tokens,
+		        usage_ratio, weekly_tokens, weekly_sonnet_tokens
 		 FROM snapshots ORDER BY taken_at DESC LIMIT 1`)
 	s, err := scanRow(row)
 	if errors.Is(err, sql.ErrNoRows) {
@@ -124,7 +142,9 @@ func (r *SnapshotRepository) Latest(ctx context.Context) (*Snapshot, error) {
 // ListBetween returns Snapshots with taken_at in [from, to], ordered ascending.
 func (r *SnapshotRepository) ListBetween(ctx context.Context, from, to time.Time) ([]Snapshot, error) {
 	rows, err := r.db.QueryContext(ctx,
-		`SELECT taken_at, block_started_at, block_ended_at, tokens_used, usage_ratio, weekly_tokens, weekly_sonnet_tokens
+		`SELECT taken_at, block_started_at, block_ended_at, tokens_used,
+		        input_tokens, output_tokens, cache_creation_tokens, cache_read_tokens,
+		        usage_ratio, weekly_tokens, weekly_sonnet_tokens
 		 FROM snapshots
 		 WHERE taken_at >= ? AND taken_at <= ?
 		 ORDER BY taken_at`,
@@ -170,11 +190,17 @@ func scan(s scanner) (*Snapshot, error) {
 		blockStartedAt     string
 		blockEndedAt       *string
 		tokensUsed         int
+		inputTokens        int
+		outputTokens       int
+		cacheCreation      int
+		cacheRead          int
 		usageRatio         float64
 		weeklyTokens       int
 		weeklySonnetTokens int
 	)
-	if err := s.Scan(&takenAt, &blockStartedAt, &blockEndedAt, &tokensUsed, &usageRatio, &weeklyTokens, &weeklySonnetTokens); err != nil {
+	if err := s.Scan(&takenAt, &blockStartedAt, &blockEndedAt, &tokensUsed,
+		&inputTokens, &outputTokens, &cacheCreation, &cacheRead,
+		&usageRatio, &weeklyTokens, &weeklySonnetTokens); err != nil {
 		return nil, err
 	}
 
@@ -188,9 +214,15 @@ func scan(s scanner) (*Snapshot, error) {
 	}
 
 	snap := &Snapshot{
-		TakenAt:            ta.UTC(),
-		BlockStartedAt:     bs.UTC(),
-		TokensUsed:         tokensUsed,
+		TakenAt:        ta.UTC(),
+		BlockStartedAt: bs.UTC(),
+		TokensUsed:     tokensUsed,
+		Tokens: blocks.TokenBreakdown{
+			Input:         inputTokens,
+			Output:        outputTokens,
+			CacheCreation: cacheCreation,
+			CacheRead:     cacheRead,
+		},
 		UsageRatio:         usageRatio,
 		WeeklyTokens:       weeklyTokens,
 		WeeklySonnetTokens: weeklySonnetTokens,

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -72,14 +72,22 @@ func writeError(w http.ResponseWriter, status int, msg string) {
 
 // --- /usage/snapshots ---
 
+type tokenBreakdown struct {
+	Input         int `json:"input"`
+	Output        int `json:"output"`
+	CacheCreation int `json:"cache_creation"`
+	CacheRead     int `json:"cache_read"`
+}
+
 type snapshotItem struct {
-	TakenAt            string  `json:"taken_at"`
-	BlockStartedAt     string  `json:"block_started_at"`
-	BlockEndedAt       string  `json:"block_ended_at,omitempty"`
-	SessionTokens      int     `json:"session_tokens"`
-	SessionRatio       float64 `json:"session_ratio"`
-	WeeklyTokens       int     `json:"weekly_tokens"`
-	WeeklySonnetTokens int     `json:"weekly_sonnet_tokens"`
+	TakenAt            string          `json:"taken_at"`
+	BlockStartedAt     string          `json:"block_started_at"`
+	BlockEndedAt       string          `json:"block_ended_at,omitempty"`
+	SessionTokens      int             `json:"session_tokens"`
+	Tokens             tokenBreakdown  `json:"tokens"`
+	SessionRatio       float64         `json:"session_ratio"`
+	WeeklyTokens       int             `json:"weekly_tokens"`
+	WeeklySonnetTokens int             `json:"weekly_sonnet_tokens"`
 }
 
 type snapshotsResponse struct {
@@ -106,9 +114,15 @@ func (h *Handler) Snapshots(w http.ResponseWriter, r *http.Request) {
 	items := make([]snapshotItem, 0, len(snaps))
 	for _, s := range snaps {
 		item := snapshotItem{
-			TakenAt:            s.TakenAt.In(jst).Format(jsonTimeFormat),
-			BlockStartedAt:     s.BlockStartedAt.In(jst).Format(jsonTimeFormat),
-			SessionTokens:      s.TokensUsed,
+			TakenAt:        s.TakenAt.In(jst).Format(jsonTimeFormat),
+			BlockStartedAt: s.BlockStartedAt.In(jst).Format(jsonTimeFormat),
+			SessionTokens:  s.TokensUsed,
+			Tokens: tokenBreakdown{
+				Input:         s.Tokens.Input,
+				Output:        s.Tokens.Output,
+				CacheCreation: s.Tokens.CacheCreation,
+				CacheRead:     s.Tokens.CacheRead,
+			},
 			SessionRatio:       s.UsageRatio,
 			WeeklyTokens:       s.WeeklyTokens,
 			WeeklySonnetTokens: s.WeeklySonnetTokens,

--- a/internal/service/usage.go
+++ b/internal/service/usage.go
@@ -74,11 +74,12 @@ func ValidateConfig(cfg Config) error {
 
 // UsageResult holds session and weekly usage metrics.
 type UsageResult struct {
-	SessionTokens int
-	SessionLimit  int
-	SessionRatio  float64
-	SessionEndsAt *time.Time
-	ActiveBlock   *blocks.Block
+	SessionTokens   int
+	SessionBreakdown blocks.TokenBreakdown
+	SessionLimit    int
+	SessionRatio    float64
+	SessionEndsAt   *time.Time
+	ActiveBlock     *blocks.Block
 
 	WeeklyTokens       int
 	WeeklyLimit        int
@@ -108,6 +109,7 @@ func Compute(cfg Config) (*UsageResult, error) {
 
 	if active != nil {
 		result.SessionTokens = active.TotalTokens
+		result.SessionBreakdown = active.Tokens
 		result.ActiveBlock = active
 		end := active.EndTime
 		result.SessionEndsAt = &end


### PR DESCRIPTION
## 背景

Issue #20 のコメントで、将来の解析のためにトークンを個別保存すべきとの方針。互換性不要。

## 変更内容

### blocks.TokenBreakdown 構造体を新設

```go
type TokenBreakdown struct {
    Input         int
    Output        int
    CacheCreation int
    CacheRead     int
}
```

`Block` に `Tokens TokenBreakdown` フィールドとして埋め込み。

### snapshots テーブルに4カラム追加

| カラム | 内容 |
|---|---|
| `input_tokens` | inputTokens |
| `output_tokens` | outputTokens |
| `cache_creation_tokens` | cacheCreationInputTokens |
| `cache_read_tokens` | cacheReadInputTokens |

既存DBへは `ALTER TABLE ADD COLUMN DEFAULT 0` で idempotent に追加（既存データは 0 埋め）。

### UsageResult.SessionBreakdown

`service.UsageResult` に `SessionBreakdown blocks.TokenBreakdown` を追加。`cmd/snapshot` がこれを Snapshot に渡す。

## テスト

- 既存テスト全通過
- `go build ./...` 通過

## 関連

- Issue #20