### PR TITLE
feat: モデル別トークン内訳の計測機能を追加 (Issue #36)

### DIFF
--- a/cmd/current/main.go
+++ b/cmd/current/main.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"sort"
 	"time"
 
 	"github.com/rengotaku/claude-usage-tracker/internal/cache"
@@ -31,13 +32,14 @@ type jsonOutput struct {
 		EndsAt     string             `json:"ends_at,omitempty"`
 	} `json:"session"`
 	Weekly struct {
-		TokensUsed   int     `json:"tokens_used"`
-		Limit        int     `json:"limit,omitempty"`
-		Ratio        float64 `json:"ratio,omitempty"`
-		SonnetTokens int     `json:"sonnet_tokens_used"`
-		SonnetLimit  int     `json:"sonnet_limit,omitempty"`
-		SonnetRatio  float64 `json:"sonnet_ratio,omitempty"`
-		ResetsAt     string  `json:"resets_at"`
+		TokensUsed     int                            `json:"tokens_used"`
+		Limit          int                            `json:"limit,omitempty"`
+		Ratio          float64                        `json:"ratio,omitempty"`
+		SonnetTokens   int                            `json:"sonnet_tokens_used"`
+		SonnetLimit    int                            `json:"sonnet_limit,omitempty"`
+		SonnetRatio    float64                        `json:"sonnet_ratio,omitempty"`
+		ResetsAt       string                         `json:"resets_at"`
+		ModelBreakdown map[string]tokenBreakdownJSON  `json:"model_breakdown,omitempty"`
 	} `json:"weekly"`
 }
 
@@ -46,12 +48,15 @@ func main() {
 
 	noCache := false
 	jsonFlag := false
+	modelBreakdown := false
 	for _, arg := range os.Args[1:] {
 		switch arg {
 		case "--json":
 			jsonFlag = true
 		case "--no-cache":
 			noCache = true
+		case "--model-breakdown":
+			modelBreakdown = true
 		}
 	}
 
@@ -112,6 +117,17 @@ func main() {
 		out.Weekly.SonnetLimit = result.WeeklySonnetLimit
 		out.Weekly.SonnetRatio = result.WeeklySonnetRatio
 		out.Weekly.ResetsAt = result.WeeklyResetsAt.In(jst).Format("2006-01-02T15:04:05+09:00")
+		if len(result.WeeklyModelBreakdown) > 0 {
+			out.Weekly.ModelBreakdown = make(map[string]tokenBreakdownJSON, len(result.WeeklyModelBreakdown))
+			for model, bd := range result.WeeklyModelBreakdown {
+				out.Weekly.ModelBreakdown[model] = tokenBreakdownJSON{
+					Input:         bd.Input,
+					Output:        bd.Output,
+					CacheCreation: bd.CacheCreation,
+					CacheRead:     bd.CacheRead,
+				}
+			}
+		}
 
 		enc := json.NewEncoder(os.Stdout)
 		enc.SetIndent("", "  ")
@@ -129,6 +145,19 @@ func main() {
 		formatM(b.Input), formatM(b.Output), formatM(b.CacheCreation), formatM(b.CacheRead))
 	fmt.Printf("Weekly (All)      %s\n", weeklyLine(result.WeeklyTokens, result.WeeklyLimit, result.WeeklyRatio, resetsAt))
 	fmt.Printf("Weekly (Sonnet)   %s\n", weeklyLine(result.WeeklySonnetTokens, result.WeeklySonnetLimit, result.WeeklySonnetRatio, resetsAt))
+
+	if modelBreakdown && len(result.WeeklyModelBreakdown) > 0 {
+		fmt.Println("Weekly by model:")
+		models := make([]string, 0, len(result.WeeklyModelBreakdown))
+		for m := range result.WeeklyModelBreakdown {
+			models = append(models, m)
+		}
+		sort.Strings(models)
+		for _, m := range models {
+			bd := result.WeeklyModelBreakdown[m]
+			fmt.Printf("  %-38s %s\n", m, formatM(bd.Total()))
+		}
+	}
 }
 
 func sessionLine(r *service.UsageResult) string {

--- a/cmd/snapshot/main.go
+++ b/cmd/snapshot/main.go
@@ -39,12 +39,13 @@ func main() {
 	defer repo.Close()
 
 	snap := repository.Snapshot{
-		TakenAt:            time.Now().UTC(),
-		TokensUsed:         result.SessionTokens,
-		Tokens:             result.SessionBreakdown,
-		UsageRatio:         result.SessionRatio,
-		WeeklyTokens:       result.WeeklyTokens,
-		WeeklySonnetTokens: result.WeeklySonnetTokens,
+		TakenAt:              time.Now().UTC(),
+		TokensUsed:           result.SessionTokens,
+		Tokens:               result.SessionBreakdown,
+		UsageRatio:           result.SessionRatio,
+		WeeklyTokens:         result.WeeklyTokens,
+		WeeklySonnetTokens:   result.WeeklySonnetTokens,
+		WeeklyModelBreakdown: result.WeeklyModelBreakdown,
 	}
 	if result.ActiveBlock != nil {
 		snap.BlockStartedAt = result.ActiveBlock.StartTime

--- a/internal/blocks/blocks.go
+++ b/internal/blocks/blocks.go
@@ -24,12 +24,13 @@ func (t TokenBreakdown) Total() int {
 
 // Block represents a 5-hour billing period.
 type Block struct {
-	StartTime   time.Time
-	EndTime     time.Time
-	IsActive    bool
-	TotalTokens int
-	Tokens      TokenBreakdown
-	EntryCount  int
+	StartTime      time.Time
+	EndTime        time.Time
+	IsActive       bool
+	TotalTokens    int
+	Tokens         TokenBreakdown
+	EntryCount     int
+	ModelBreakdown map[string]TokenBreakdown // per-model token breakdown; empty string keys excluded
 }
 
 // Build converts a slice of UsageEntry into 5-hour blocks sorted by StartTime.
@@ -51,8 +52,9 @@ func Build(entries []jsonl.UsageEntry) []Block {
 		if current == nil || !e.Timestamp.Before(current.EndTime) {
 			start := e.Timestamp.UTC().Truncate(time.Second)
 			b := Block{
-				StartTime: start,
-				EndTime:   start.Add(blockDuration),
+				StartTime:      start,
+				EndTime:        start.Add(blockDuration),
+				ModelBreakdown: make(map[string]TokenBreakdown),
 			}
 			blocks = append(blocks, b)
 			current = &blocks[len(blocks)-1]
@@ -63,6 +65,14 @@ func Build(entries []jsonl.UsageEntry) []Block {
 		current.Tokens.CacheCreation += e.CacheCreationInputTokens
 		current.Tokens.CacheRead += e.CacheReadInputTokens
 		current.EntryCount++
+		if e.Model != "" {
+			mb := current.ModelBreakdown[e.Model]
+			mb.Input += e.InputTokens
+			mb.Output += e.OutputTokens
+			mb.CacheCreation += e.CacheCreationInputTokens
+			mb.CacheRead += e.CacheReadInputTokens
+			current.ModelBreakdown[e.Model] = mb
+		}
 	}
 
 	now := time.Now().UTC()

--- a/internal/blocks/blocks_test.go
+++ b/internal/blocks/blocks_test.go
@@ -18,6 +18,17 @@ func entry(ts time.Time, input, output, cacheCreate, cacheRead int) jsonl.UsageE
 	}
 }
 
+func entryWithModel(ts time.Time, model string, input, output, cacheCreate, cacheRead int) jsonl.UsageEntry {
+	return jsonl.UsageEntry{
+		Timestamp:                ts,
+		Model:                    model,
+		InputTokens:              input,
+		OutputTokens:             output,
+		CacheCreationInputTokens: cacheCreate,
+		CacheReadInputTokens:     cacheRead,
+	}
+}
+
 func utc(year int, month time.Month, day, hour, min int) time.Time {
 	return time.Date(year, month, day, hour, min, 0, 0, time.UTC)
 }
@@ -113,6 +124,49 @@ func TestBuild_UnsortedEntriesAreSorted(t *testing.T) {
 	}
 	if result[0].EntryCount != 2 {
 		t.Errorf("EntryCount: want 2, got %d", result[0].EntryCount)
+	}
+}
+
+func TestBuild_ModelBreakdown(t *testing.T) {
+	entries := []jsonl.UsageEntry{
+		entryWithModel(utc(2026, 4, 19, 10, 0), "claude-sonnet-4-6", 100, 200, 0, 0),
+		entryWithModel(utc(2026, 4, 19, 11, 0), "claude-haiku-4-5", 50, 30, 10, 5),
+		entryWithModel(utc(2026, 4, 19, 12, 0), "claude-sonnet-4-6", 20, 10, 0, 0),
+	}
+	result := blocks.Build(entries)
+	if len(result) != 1 {
+		t.Fatalf("expected 1 block, got %d", len(result))
+	}
+	b := result[0]
+
+	sonnet, ok := b.ModelBreakdown["claude-sonnet-4-6"]
+	if !ok {
+		t.Fatal("expected claude-sonnet-4-6 in ModelBreakdown")
+	}
+	if sonnet.Input != 120 || sonnet.Output != 210 {
+		t.Errorf("sonnet: want Input=120,Output=210 got Input=%d,Output=%d", sonnet.Input, sonnet.Output)
+	}
+
+	haiku, ok := b.ModelBreakdown["claude-haiku-4-5"]
+	if !ok {
+		t.Fatal("expected claude-haiku-4-5 in ModelBreakdown")
+	}
+	if haiku.Input != 50 || haiku.Output != 30 || haiku.CacheCreation != 10 || haiku.CacheRead != 5 {
+		t.Errorf("haiku: want Input=50,Output=30,CacheCreation=10,CacheRead=5, got Input=%d,Output=%d,CacheCreation=%d,CacheRead=%d",
+			haiku.Input, haiku.Output, haiku.CacheCreation, haiku.CacheRead)
+	}
+}
+
+func TestBuild_ModelBreakdown_EmptyModel(t *testing.T) {
+	entries := []jsonl.UsageEntry{
+		entry(utc(2026, 4, 19, 10, 0), 10, 20, 0, 0),
+	}
+	result := blocks.Build(entries)
+	if len(result) != 1 {
+		t.Fatalf("expected 1 block, got %d", len(result))
+	}
+	if len(result[0].ModelBreakdown) != 0 {
+		t.Errorf("expected empty ModelBreakdown for entry with no model, got %v", result[0].ModelBreakdown)
 	}
 }
 

--- a/internal/cache/cache.go
+++ b/internal/cache/cache.go
@@ -19,13 +19,14 @@ type entry struct {
 	SessionEndsAt *time.Time     `json:"session_ends_at,omitempty"`
 	ActiveBlock   *blocks.Block  `json:"active_block,omitempty"`
 
-	WeeklyTokens       int       `json:"weekly_tokens"`
-	WeeklyLimit        int       `json:"weekly_limit"`
-	WeeklyRatio        float64   `json:"weekly_ratio"`
-	WeeklySonnetTokens int       `json:"weekly_sonnet_tokens"`
-	WeeklySonnetLimit  int       `json:"weekly_sonnet_limit"`
-	WeeklySonnetRatio  float64   `json:"weekly_sonnet_ratio"`
-	WeeklyResetsAt     time.Time `json:"weekly_resets_at"`
+	WeeklyTokens         int                              `json:"weekly_tokens"`
+	WeeklyLimit          int                              `json:"weekly_limit"`
+	WeeklyRatio          float64                          `json:"weekly_ratio"`
+	WeeklySonnetTokens   int                              `json:"weekly_sonnet_tokens"`
+	WeeklySonnetLimit    int                              `json:"weekly_sonnet_limit"`
+	WeeklySonnetRatio    float64                          `json:"weekly_sonnet_ratio"`
+	WeeklyResetsAt       time.Time                        `json:"weekly_resets_at"`
+	WeeklyModelBreakdown map[string]blocks.TokenBreakdown `json:"weekly_model_breakdown,omitempty"`
 }
 
 // Load reads a cached UsageResult from path. Returns nil if the cache is missing,
@@ -49,37 +50,39 @@ func Load(path string, ttl time.Duration) (*service.UsageResult, error) {
 	}
 
 	return &service.UsageResult{
-		SessionTokens:      e.SessionTokens,
-		SessionLimit:       e.SessionLimit,
-		SessionRatio:       e.SessionRatio,
-		SessionEndsAt:      e.SessionEndsAt,
-		ActiveBlock:        e.ActiveBlock,
-		WeeklyTokens:       e.WeeklyTokens,
-		WeeklyLimit:        e.WeeklyLimit,
-		WeeklyRatio:        e.WeeklyRatio,
-		WeeklySonnetTokens: e.WeeklySonnetTokens,
-		WeeklySonnetLimit:  e.WeeklySonnetLimit,
-		WeeklySonnetRatio:  e.WeeklySonnetRatio,
-		WeeklyResetsAt:     e.WeeklyResetsAt,
+		SessionTokens:        e.SessionTokens,
+		SessionLimit:         e.SessionLimit,
+		SessionRatio:         e.SessionRatio,
+		SessionEndsAt:        e.SessionEndsAt,
+		ActiveBlock:          e.ActiveBlock,
+		WeeklyTokens:         e.WeeklyTokens,
+		WeeklyLimit:          e.WeeklyLimit,
+		WeeklyRatio:          e.WeeklyRatio,
+		WeeklySonnetTokens:   e.WeeklySonnetTokens,
+		WeeklySonnetLimit:    e.WeeklySonnetLimit,
+		WeeklySonnetRatio:    e.WeeklySonnetRatio,
+		WeeklyResetsAt:       e.WeeklyResetsAt,
+		WeeklyModelBreakdown: e.WeeklyModelBreakdown,
 	}, nil
 }
 
 // Save writes result to path as a JSON cache entry.
 func Save(path string, result *service.UsageResult) error {
 	e := entry{
-		CachedAt:           time.Now(),
-		SessionTokens:      result.SessionTokens,
-		SessionLimit:       result.SessionLimit,
-		SessionRatio:       result.SessionRatio,
-		SessionEndsAt:      result.SessionEndsAt,
-		ActiveBlock:        result.ActiveBlock,
-		WeeklyTokens:       result.WeeklyTokens,
-		WeeklyLimit:        result.WeeklyLimit,
-		WeeklyRatio:        result.WeeklyRatio,
-		WeeklySonnetTokens: result.WeeklySonnetTokens,
-		WeeklySonnetLimit:  result.WeeklySonnetLimit,
-		WeeklySonnetRatio:  result.WeeklySonnetRatio,
-		WeeklyResetsAt:     result.WeeklyResetsAt,
+		CachedAt:             time.Now(),
+		SessionTokens:        result.SessionTokens,
+		SessionLimit:         result.SessionLimit,
+		SessionRatio:         result.SessionRatio,
+		SessionEndsAt:        result.SessionEndsAt,
+		ActiveBlock:          result.ActiveBlock,
+		WeeklyTokens:         result.WeeklyTokens,
+		WeeklyLimit:          result.WeeklyLimit,
+		WeeklyRatio:          result.WeeklyRatio,
+		WeeklySonnetTokens:   result.WeeklySonnetTokens,
+		WeeklySonnetLimit:    result.WeeklySonnetLimit,
+		WeeklySonnetRatio:    result.WeeklySonnetRatio,
+		WeeklyResetsAt:       result.WeeklyResetsAt,
+		WeeklyModelBreakdown: result.WeeklyModelBreakdown,
 	}
 	data, err := json.Marshal(e)
 	if err != nil {

--- a/internal/repository/snapshot.go
+++ b/internal/repository/snapshot.go
@@ -3,6 +3,7 @@ package repository
 import (
 	"context"
 	"database/sql"
+	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
@@ -19,14 +20,15 @@ const timeLayout = time.RFC3339
 
 // Snapshot represents a point-in-time record of token usage within a block.
 type Snapshot struct {
-	TakenAt            time.Time
-	BlockStartedAt     time.Time
-	BlockEndedAt       *time.Time
-	TokensUsed         int
-	Tokens             blocks.TokenBreakdown
-	UsageRatio         float64
-	WeeklyTokens       int
-	WeeklySonnetTokens int
+	TakenAt              time.Time
+	BlockStartedAt       time.Time
+	BlockEndedAt         *time.Time
+	TokensUsed           int
+	Tokens               blocks.TokenBreakdown
+	UsageRatio           float64
+	WeeklyTokens         int
+	WeeklySonnetTokens   int
+	WeeklyModelBreakdown map[string]blocks.TokenBreakdown
 }
 
 // SnapshotRepository persists Snapshot records to SQLite.
@@ -85,6 +87,7 @@ func (r *SnapshotRepository) migrate(ctx context.Context) error {
 		"ALTER TABLE snapshots ADD COLUMN output_tokens         INTEGER NOT NULL DEFAULT 0",
 		"ALTER TABLE snapshots ADD COLUMN cache_creation_tokens INTEGER NOT NULL DEFAULT 0",
 		"ALTER TABLE snapshots ADD COLUMN cache_read_tokens     INTEGER NOT NULL DEFAULT 0",
+		"ALTER TABLE snapshots ADD COLUMN model_breakdown       TEXT NOT NULL DEFAULT '{}'",
 	} {
 		if _, err := r.db.ExecContext(ctx, col); err != nil {
 			if !strings.Contains(err.Error(), "duplicate column name") {
@@ -102,11 +105,16 @@ func (r *SnapshotRepository) Save(ctx context.Context, s Snapshot) error {
 		v := s.BlockEndedAt.UTC().Truncate(time.Second).Format(timeLayout)
 		endedAt = &v
 	}
-	_, err := r.db.ExecContext(ctx,
+	mbJSON, err := json.Marshal(s.WeeklyModelBreakdown)
+	if err != nil {
+		return fmt.Errorf("marshal model_breakdown: %w", err)
+	}
+	_, err = r.db.ExecContext(ctx,
 		`INSERT OR REPLACE INTO snapshots
 			(taken_at, block_started_at, block_ended_at, tokens_used, input_tokens, output_tokens,
-			 cache_creation_tokens, cache_read_tokens, usage_ratio, weekly_tokens, weekly_sonnet_tokens)
-		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+			 cache_creation_tokens, cache_read_tokens, usage_ratio, weekly_tokens, weekly_sonnet_tokens,
+			 model_breakdown)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		s.TakenAt.UTC().Truncate(time.Second).Format(timeLayout),
 		s.BlockStartedAt.UTC().Truncate(time.Second).Format(timeLayout),
 		endedAt,
@@ -118,6 +126,7 @@ func (r *SnapshotRepository) Save(ctx context.Context, s Snapshot) error {
 		s.UsageRatio,
 		s.WeeklyTokens,
 		s.WeeklySonnetTokens,
+		string(mbJSON),
 	)
 	if err != nil {
 		return fmt.Errorf("save snapshot: %w", err)
@@ -130,7 +139,7 @@ func (r *SnapshotRepository) Latest(ctx context.Context) (*Snapshot, error) {
 	row := r.db.QueryRowContext(ctx,
 		`SELECT taken_at, block_started_at, block_ended_at, tokens_used,
 		        input_tokens, output_tokens, cache_creation_tokens, cache_read_tokens,
-		        usage_ratio, weekly_tokens, weekly_sonnet_tokens
+		        usage_ratio, weekly_tokens, weekly_sonnet_tokens, model_breakdown
 		 FROM snapshots ORDER BY taken_at DESC LIMIT 1`)
 	s, err := scanRow(row)
 	if errors.Is(err, sql.ErrNoRows) {
@@ -144,7 +153,7 @@ func (r *SnapshotRepository) ListBetween(ctx context.Context, from, to time.Time
 	rows, err := r.db.QueryContext(ctx,
 		`SELECT taken_at, block_started_at, block_ended_at, tokens_used,
 		        input_tokens, output_tokens, cache_creation_tokens, cache_read_tokens,
-		        usage_ratio, weekly_tokens, weekly_sonnet_tokens
+		        usage_ratio, weekly_tokens, weekly_sonnet_tokens, model_breakdown
 		 FROM snapshots
 		 WHERE taken_at >= ? AND taken_at <= ?
 		 ORDER BY taken_at`,
@@ -197,10 +206,11 @@ func scan(s scanner) (*Snapshot, error) {
 		usageRatio         float64
 		weeklyTokens       int
 		weeklySonnetTokens int
+		modelBreakdownJSON string
 	)
 	if err := s.Scan(&takenAt, &blockStartedAt, &blockEndedAt, &tokensUsed,
 		&inputTokens, &outputTokens, &cacheCreation, &cacheRead,
-		&usageRatio, &weeklyTokens, &weeklySonnetTokens); err != nil {
+		&usageRatio, &weeklyTokens, &weeklySonnetTokens, &modelBreakdownJSON); err != nil {
 		return nil, err
 	}
 
@@ -213,6 +223,13 @@ func scan(s scanner) (*Snapshot, error) {
 		return nil, fmt.Errorf("parse block_started_at: %w", err)
 	}
 
+	var modelBreakdown map[string]blocks.TokenBreakdown
+	if modelBreakdownJSON != "" && modelBreakdownJSON != "{}" {
+		if err := json.Unmarshal([]byte(modelBreakdownJSON), &modelBreakdown); err != nil {
+			return nil, fmt.Errorf("unmarshal model_breakdown: %w", err)
+		}
+	}
+
 	snap := &Snapshot{
 		TakenAt:        ta.UTC(),
 		BlockStartedAt: bs.UTC(),
@@ -223,9 +240,10 @@ func scan(s scanner) (*Snapshot, error) {
 			CacheCreation: cacheCreation,
 			CacheRead:     cacheRead,
 		},
-		UsageRatio:         usageRatio,
-		WeeklyTokens:       weeklyTokens,
-		WeeklySonnetTokens: weeklySonnetTokens,
+		UsageRatio:           usageRatio,
+		WeeklyTokens:         weeklyTokens,
+		WeeklySonnetTokens:   weeklySonnetTokens,
+		WeeklyModelBreakdown: modelBreakdown,
 	}
 	if blockEndedAt != nil {
 		be, err := time.Parse(timeLayout, *blockEndedAt)

--- a/internal/repository/snapshot_test.go
+++ b/internal/repository/snapshot_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/rengotaku/claude-usage-tracker/internal/blocks"
 	"github.com/rengotaku/claude-usage-tracker/internal/repository"
 )
 
@@ -160,6 +161,47 @@ func TestLatestReturnsNewest(t *testing.T) {
 	}
 	if got.TokensUsed != 999 {
 		t.Errorf("Latest should return newest: got TokensUsed=%d, want 999", got.TokensUsed)
+	}
+}
+
+func TestSaveAndLatest_ModelBreakdown(t *testing.T) {
+	r := newTestRepo(t)
+	ctx := context.Background()
+
+	now := time.Now().UTC().Truncate(time.Second)
+	s := repository.Snapshot{
+		TakenAt:        now,
+		BlockStartedAt: now,
+		TokensUsed:     1000,
+		UsageRatio:     0.5,
+		WeeklyModelBreakdown: map[string]blocks.TokenBreakdown{
+			"claude-sonnet-4-6": {Input: 100, Output: 200, CacheCreation: 10, CacheRead: 50},
+			"claude-haiku-4-5":  {Input: 50, Output: 30},
+		},
+	}
+	if err := r.Save(ctx, s); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	got, err := r.Latest(ctx)
+	if err != nil {
+		t.Fatalf("latest: %v", err)
+	}
+	if got == nil {
+		t.Fatal("expected snapshot")
+	}
+	sonnet, ok := got.WeeklyModelBreakdown["claude-sonnet-4-6"]
+	if !ok {
+		t.Fatal("expected claude-sonnet-4-6 in WeeklyModelBreakdown")
+	}
+	if sonnet.Input != 100 || sonnet.Output != 200 || sonnet.CacheCreation != 10 || sonnet.CacheRead != 50 {
+		t.Errorf("sonnet: want {100 200 10 50}, got %+v", sonnet)
+	}
+	haiku, ok := got.WeeklyModelBreakdown["claude-haiku-4-5"]
+	if !ok {
+		t.Fatal("expected claude-haiku-4-5 in WeeklyModelBreakdown")
+	}
+	if haiku.Input != 50 || haiku.Output != 30 {
+		t.Errorf("haiku: want {50 30 0 0}, got %+v", haiku)
 	}
 }
 

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -80,14 +80,15 @@ type tokenBreakdown struct {
 }
 
 type snapshotItem struct {
-	TakenAt            string          `json:"taken_at"`
-	BlockStartedAt     string          `json:"block_started_at"`
-	BlockEndedAt       string          `json:"block_ended_at,omitempty"`
-	SessionTokens      int             `json:"session_tokens"`
-	Tokens             tokenBreakdown  `json:"tokens"`
-	SessionRatio       float64         `json:"session_ratio"`
-	WeeklyTokens       int             `json:"weekly_tokens"`
-	WeeklySonnetTokens int             `json:"weekly_sonnet_tokens"`
+	TakenAt              string                    `json:"taken_at"`
+	BlockStartedAt       string                    `json:"block_started_at"`
+	BlockEndedAt         string                    `json:"block_ended_at,omitempty"`
+	SessionTokens        int                       `json:"session_tokens"`
+	Tokens               tokenBreakdown            `json:"tokens"`
+	SessionRatio         float64                   `json:"session_ratio"`
+	WeeklyTokens         int                       `json:"weekly_tokens"`
+	WeeklySonnetTokens   int                       `json:"weekly_sonnet_tokens"`
+	WeeklyModelBreakdown map[string]tokenBreakdown `json:"weekly_model_breakdown,omitempty"`
 }
 
 type snapshotsResponse struct {
@@ -126,6 +127,17 @@ func (h *Handler) Snapshots(w http.ResponseWriter, r *http.Request) {
 			SessionRatio:       s.UsageRatio,
 			WeeklyTokens:       s.WeeklyTokens,
 			WeeklySonnetTokens: s.WeeklySonnetTokens,
+		}
+		if len(s.WeeklyModelBreakdown) > 0 {
+			item.WeeklyModelBreakdown = make(map[string]tokenBreakdown, len(s.WeeklyModelBreakdown))
+			for model, bd := range s.WeeklyModelBreakdown {
+				item.WeeklyModelBreakdown[model] = tokenBreakdown{
+					Input:         bd.Input,
+					Output:        bd.Output,
+					CacheCreation: bd.CacheCreation,
+					CacheRead:     bd.CacheRead,
+				}
+			}
 		}
 		if s.BlockEndedAt != nil {
 			item.BlockEndedAt = s.BlockEndedAt.In(jst).Format(jsonTimeFormat)

--- a/internal/service/usage.go
+++ b/internal/service/usage.go
@@ -81,13 +81,14 @@ type UsageResult struct {
 	SessionEndsAt   *time.Time
 	ActiveBlock     *blocks.Block
 
-	WeeklyTokens       int
-	WeeklyLimit        int
-	WeeklyRatio        float64
-	WeeklySonnetTokens int
-	WeeklySonnetLimit  int
-	WeeklySonnetRatio  float64
-	WeeklyResetsAt     time.Time
+	WeeklyTokens        int
+	WeeklyLimit         int
+	WeeklyRatio         float64
+	WeeklySonnetTokens  int
+	WeeklySonnetLimit   int
+	WeeklySonnetRatio   float64
+	WeeklyResetsAt      time.Time
+	WeeklyModelBreakdown map[string]blocks.TokenBreakdown // per-model token breakdown for current week
 }
 
 // Compute parses JSONL logs and returns session + weekly usage.
@@ -101,10 +102,11 @@ func Compute(cfg Config) (*UsageResult, error) {
 	active := blocks.ActiveBlock(bs)
 
 	result := &UsageResult{
-		SessionLimit:      cfg.SessionLimit,
-		WeeklyLimit:       cfg.WeeklyLimit,
-		WeeklySonnetLimit: cfg.WeeklySonnetLimit,
-		WeeklyResetsAt:    nextWeeklyReset(cfg.WeeklyResetDay, cfg.WeeklyResetHour),
+		SessionLimit:         cfg.SessionLimit,
+		WeeklyLimit:          cfg.WeeklyLimit,
+		WeeklySonnetLimit:    cfg.WeeklySonnetLimit,
+		WeeklyResetsAt:       nextWeeklyReset(cfg.WeeklyResetDay, cfg.WeeklyResetHour),
+		WeeklyModelBreakdown: make(map[string]blocks.TokenBreakdown),
 	}
 
 	if active != nil {
@@ -127,6 +129,14 @@ func Compute(cfg Config) (*UsageResult, error) {
 		result.WeeklyTokens += t
 		if isSonnet(e.Model) {
 			result.WeeklySonnetTokens += t
+		}
+		if e.Model != "" {
+			mb := result.WeeklyModelBreakdown[e.Model]
+			mb.Input += e.InputTokens
+			mb.Output += e.OutputTokens
+			mb.CacheCreation += e.CacheCreationInputTokens
+			mb.CacheRead += e.CacheReadInputTokens
+			result.WeeklyModelBreakdown[e.Model] = mb
 		}
 	}
 	if cfg.WeeklyLimit > 0 {

--- a/internal/service/usage_test.go
+++ b/internal/service/usage_test.go
@@ -3,6 +3,7 @@ package service_test
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -90,6 +91,36 @@ func TestCompute_WeeklyLimit(t *testing.T) {
 	wantSonnet := float64(300) / float64(500_000)
 	if result.WeeklySonnetRatio != wantSonnet {
 		t.Errorf("expected sonnet ratio %f, got %f", wantSonnet, result.WeeklySonnetRatio)
+	}
+}
+
+func TestCompute_WeeklyModelBreakdown(t *testing.T) {
+	dir := t.TempDir()
+	now := time.Now().UTC()
+	writeMixedJSONL(t, dir, now)
+
+	cfg := service.Config{LogDir: dir}
+	result, err := service.Compute(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(result.WeeklyModelBreakdown) != 2 {
+		t.Fatalf("expected 2 models in WeeklyModelBreakdown, got %d", len(result.WeeklyModelBreakdown))
+	}
+	sonnet, ok := result.WeeklyModelBreakdown["claude-sonnet-4-6"]
+	if !ok {
+		t.Fatal("expected claude-sonnet-4-6 in WeeklyModelBreakdown")
+	}
+	if sonnet.Input != 100 || sonnet.Output != 200 {
+		t.Errorf("sonnet: want Input=100,Output=200, got Input=%d,Output=%d", sonnet.Input, sonnet.Output)
+	}
+	haiku, ok := result.WeeklyModelBreakdown["claude-haiku-4-5"]
+	if !ok {
+		t.Fatal("expected claude-haiku-4-5 in WeeklyModelBreakdown")
+	}
+	if haiku.Input != 50 || haiku.Output != 30 {
+		t.Errorf("haiku: want Input=50,Output=30, got Input=%d,Output=%d", haiku.Input, haiku.Output)
 	}
 }
 
@@ -260,6 +291,18 @@ func writeCredentials(t *testing.T, home, body string) {
 	}
 	path := filepath.Join(credDir, ".credentials.json")
 	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func writeMixedJSONL(t *testing.T, dir string, ts time.Time) {
+	t.Helper()
+	lines := []string{
+		`{"type":"assistant","uuid":"u1","timestamp":"` + ts.Format(time.RFC3339) + `","message":{"id":"msg1","model":"claude-sonnet-4-6","usage":{"input_tokens":100,"output_tokens":200,"cache_creation_input_tokens":0,"cache_read_input_tokens":0}}}`,
+		`{"type":"assistant","uuid":"u2","timestamp":"` + ts.Add(time.Minute).Format(time.RFC3339) + `","message":{"id":"msg2","model":"claude-haiku-4-5","usage":{"input_tokens":50,"output_tokens":30,"cache_creation_input_tokens":0,"cache_read_input_tokens":0}}}`,
+	}
+	path := filepath.Join(dir, "test.jsonl")
+	if err := os.WriteFile(path, []byte(strings.Join(lines, "\n")+"\n"), 0o644); err != nil {
 		t.Fatal(err)
 	}
 }


### PR DESCRIPTION
## 概要

Issue #36: モデル別トークン内訳の計測機能を追加

> Parent: #35

## 変更点

- feat: snapshotにモデル別内訳を保存し/usage/snapshotsレスポンスに追加
- feat: currentコマンドに--model-breakdownフラグを追加
## サブ変更

- feat: ブロックおよび週次集計にモデル別トークン内訳を追加
