### PR TITLE
feat: report コマンドを Go で実装し Python スクリプトを置き換える (#39)

### DIFF
--- a/cmd/report/main.go
+++ b/cmd/report/main.go
@@ -1,0 +1,139 @@
+package main
+
+import (
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"runtime"
+	"time"
+
+	"github.com/rengotaku/claude-usage-tracker/internal/blocks"
+	"github.com/rengotaku/claude-usage-tracker/internal/config"
+	"github.com/rengotaku/claude-usage-tracker/internal/jsonl"
+	"github.com/rengotaku/claude-usage-tracker/internal/report"
+	"github.com/rengotaku/claude-usage-tracker/internal/service"
+)
+
+var jst = time.FixedZone("JST", 9*60*60)
+
+const lastReportFile = ".local/share/claude-usage-tracker/last-usage-report.txt"
+
+func main() {
+	logger := slog.New(slog.NewJSONHandler(os.Stderr, nil))
+
+	dryRun := false
+	force := false
+	for _, arg := range os.Args[1:] {
+		switch arg {
+		case "--dry-run":
+			dryRun = true
+		case "--force":
+			force = true
+		}
+	}
+
+	appCfg, err := config.Load(config.DefaultPath())
+	if err != nil {
+		logger.Error("load config", "error", err)
+		os.Exit(1)
+	}
+
+	cfg := service.ConfigFrom(appCfg)
+	if err := service.ValidateConfig(cfg); err != nil {
+		logger.Error("invalid config", "error", err)
+		os.Exit(1)
+	}
+
+	usage, err := service.Compute(cfg)
+	if err != nil {
+		logger.Error("compute usage", "error", err)
+		os.Exit(1)
+	}
+
+	entries, err := jsonl.Parse(appCfg.LogDir)
+	if err != nil {
+		logger.Warn("parse jsonl", "error", err)
+	}
+
+	modelBreakdown := computeModelBreakdown(entries, usage.WeeklyStartsAt)
+
+	recentBlocks := buildRecentBlocks(entries)
+
+	now := time.Now().In(jst)
+	monthly := report.ComputeMonthly(entries, now)
+
+	osType := "linux"
+	if runtime.GOOS == "darwin" {
+		osType = "mac"
+	}
+
+	body := report.Build(report.Input{
+		Now:            now,
+		OSType:         osType,
+		Usage:          usage,
+		ModelBreakdown: modelBreakdown,
+		RecentBlocks:   recentBlocks,
+		Monthly:        monthly,
+	})
+
+	lastReportPath := filepath.Join(os.Getenv("HOME"), lastReportFile)
+
+	if !force && !dryRun {
+		if prev, err := os.ReadFile(lastReportPath); err == nil && string(prev) == body {
+			fmt.Println("Report unchanged since last post. Use --force to override.")
+			return
+		}
+	}
+
+	if dryRun {
+		fmt.Print(body)
+		fmt.Println("[dry-run] コメント投稿をスキップしました")
+		return
+	}
+
+	discussionID, err := report.GetDiscussionID(report.RepoOwner, report.RepoName, report.DiscussionNum)
+	if err != nil {
+		logger.Error("get discussion id", "error", err)
+		os.Exit(1)
+	}
+
+	url, err := report.PostComment(discussionID, body)
+	if err != nil {
+		logger.Error("post comment", "error", err)
+		os.Exit(1)
+	}
+
+	if err := os.MkdirAll(filepath.Dir(lastReportPath), 0o755); err != nil {
+		logger.Warn("create report dir", "error", err)
+	} else if err := os.WriteFile(lastReportPath, []byte(body), 0o644); err != nil {
+		logger.Warn("write last report", "error", err)
+	}
+
+	fmt.Printf("Posted: %s\n", url)
+}
+
+func computeModelBreakdown(entries []jsonl.UsageEntry, weekStart time.Time) map[string]int {
+	byModel := map[string]int{}
+	for _, e := range entries {
+		if e.Timestamp.Before(weekStart) {
+			continue
+		}
+		byModel[report.ClassifyModel(e.Model)] += report.TotalTokens(e)
+	}
+	return byModel
+}
+
+func buildRecentBlocks(entries []jsonl.UsageEntry) []blocks.Block {
+	bs := blocks.Build(entries)
+	cutoff := time.Now().AddDate(0, 0, -7)
+	var result []blocks.Block
+	for i := len(bs) - 1; i >= 0; i-- {
+		b := bs[i]
+		if b.StartTime.Before(cutoff) || b.TotalTokens == 0 {
+			continue
+		}
+		result = append(result, b)
+	}
+	return result
+}

--- a/deploy/launchd/com.user.claude-usage-report.plist
+++ b/deploy/launchd/com.user.claude-usage-report.plist
@@ -1,0 +1,35 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>Label</key>
+    <string>com.user.claude-usage-report</string>
+
+    <key>ProgramArguments</key>
+    <array>
+        <string>{{HOME}}/.local/bin/claude-usage-tracker-report</string>
+    </array>
+
+    <key>StartCalendarInterval</key>
+    <dict>
+        <key>Weekday</key>
+        <integer>2</integer>
+        <key>Hour</key>
+        <integer>9</integer>
+        <key>Minute</key>
+        <integer>0</integer>
+    </dict>
+
+    <key>EnvironmentVariables</key>
+    <dict>
+        <key>CLAUDE_USAGE_TRACKER_CONFIG</key>
+        <string>{{HOME}}/.config/claude-usage-tracker/config.yaml</string>
+    </dict>
+
+    <key>StandardOutPath</key>
+    <string>{{HOME}}/.local/share/claude-usage-tracker/report.log</string>
+
+    <key>StandardErrorPath</key>
+    <string>{{HOME}}/.local/share/claude-usage-tracker/report.log</string>
+</dict>
+</plist>

--- a/deploy/launchd/install.sh
+++ b/deploy/launchd/install.sh
@@ -14,11 +14,16 @@ cd "$SCRIPT_DIR/../.."
 CGO_ENABLED=0 go build -o "$BIN_DIR/claude-usage-tracker-snapshot" ./cmd/snapshot
 CGO_ENABLED=0 go build -o "$BIN_DIR/claude-usage-tracker-current" ./cmd/current
 CGO_ENABLED=0 go build -o "$BIN_DIR/claude-usage-tracker-setup" ./cmd/setup
+CGO_ENABLED=0 go build -o "$BIN_DIR/claude-usage-tracker-report" ./cmd/report
 
-echo "Installing launchd plist..."
+echo "Installing launchd plists..."
+REPORT_PLIST_NAME="com.user.claude-usage-report"
 sed "s|{{HOME}}|$HOME|g" "$SCRIPT_DIR/$PLIST_NAME.plist" > "$PLIST_DIR/$PLIST_NAME.plist"
+sed "s|{{HOME}}|$HOME|g" "$SCRIPT_DIR/$REPORT_PLIST_NAME.plist" > "$PLIST_DIR/$REPORT_PLIST_NAME.plist"
 
 launchctl unload "$PLIST_DIR/$PLIST_NAME.plist" 2>/dev/null || true
 launchctl load "$PLIST_DIR/$PLIST_NAME.plist"
+launchctl unload "$PLIST_DIR/$REPORT_PLIST_NAME.plist" 2>/dev/null || true
+launchctl load "$PLIST_DIR/$REPORT_PLIST_NAME.plist"
 
-echo "Done. Verify with: launchctl list $PLIST_NAME"
+echo "Done. Verify with: launchctl list $PLIST_NAME && launchctl list $REPORT_PLIST_NAME"

--- a/deploy/systemd/claude-usage-report.service
+++ b/deploy/systemd/claude-usage-report.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Claude usage weekly report poster
+After=network.target
+
+[Service]
+Type=oneshot
+Environment=CLAUDE_USAGE_TRACKER_CONFIG=%h/.config/claude-usage-tracker/config.yaml
+EnvironmentFile=-%h/.config/claude-usage-tracker/report-env
+ExecStart=%h/.local/bin/claude-usage-tracker-report
+StandardOutput=append:%h/.local/share/claude-usage-tracker/report.log
+StandardError=append:%h/.local/share/claude-usage-tracker/report.log

--- a/deploy/systemd/claude-usage-report.timer
+++ b/deploy/systemd/claude-usage-report.timer
@@ -1,0 +1,9 @@
+[Unit]
+Description=Claude usage weekly report timer
+
+[Timer]
+OnCalendar=Mon *-*-* 09:00:00 Asia/Tokyo
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/deploy/systemd/install.sh
+++ b/deploy/systemd/install.sh
@@ -12,12 +12,16 @@ cd "$SCRIPT_DIR/../.."
 CGO_ENABLED=0 go build -o "$BIN_DIR/claude-usage-tracker-snapshot" ./cmd/snapshot
 CGO_ENABLED=0 go build -o "$BIN_DIR/claude-usage-tracker-current" ./cmd/current
 CGO_ENABLED=0 go build -o "$BIN_DIR/claude-usage-tracker-setup" ./cmd/setup
+CGO_ENABLED=0 go build -o "$BIN_DIR/claude-usage-tracker-report" ./cmd/report
 
 echo "Installing systemd units..."
-cp "$SCRIPT_DIR/claude-usage-tracker.service" "$UNIT_DIR/"
-cp "$SCRIPT_DIR/claude-usage-tracker.timer"   "$UNIT_DIR/"
+cp "$SCRIPT_DIR/claude-usage-tracker.service"        "$UNIT_DIR/"
+cp "$SCRIPT_DIR/claude-usage-tracker.timer"          "$UNIT_DIR/"
+cp "$SCRIPT_DIR/claude-usage-report.service"         "$UNIT_DIR/"
+cp "$SCRIPT_DIR/claude-usage-report.timer"           "$UNIT_DIR/"
 
 systemctl --user daemon-reload
 systemctl --user enable --now claude-usage-tracker.timer
+systemctl --user enable --now claude-usage-report.timer
 
 echo "Done. Verify with: systemctl --user list-timers"

--- a/internal/report/builder.go
+++ b/internal/report/builder.go
@@ -1,0 +1,160 @@
+package report
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/rengotaku/claude-usage-tracker/internal/blocks"
+	"github.com/rengotaku/claude-usage-tracker/internal/service"
+)
+
+var jst = time.FixedZone("JST", 9*60*60)
+
+// Input holds all data needed to render a weekly usage report.
+type Input struct {
+	Now            time.Time
+	OSType         string
+	Usage          *service.UsageResult
+	ModelBreakdown map[string]int // classified model name → total tokens
+	RecentBlocks   []blocks.Block
+	Monthly        *MonthlyData // nil if not in first week of month
+}
+
+// Build renders the Markdown report body.
+func Build(in Input) string {
+	nowStr := in.Now.In(jst).Format("2006-01-02 15:04 JST")
+	var sb strings.Builder
+
+	fmt.Fprintf(&sb, "## 週次レポート — %s\n\n", nowStr)
+	fmt.Fprintf(&sb, "**実行ホスト**: %s\n\n", in.OSType)
+	sb.WriteString(buildSession(in.Usage))
+	sb.WriteString(buildWeekly(in.Usage, in.ModelBreakdown))
+	sb.WriteString(buildBlocks(in.RecentBlocks))
+	if in.Monthly != nil {
+		sb.WriteString(buildMonthly(in.Monthly))
+	}
+
+	return strings.TrimRight(sb.String(), "\n") + "\n"
+}
+
+func buildSession(u *service.UsageResult) string {
+	var sb strings.Builder
+	sb.WriteString("### セッション (現在の5h ブロック)\n\n")
+
+	usageLine := fmtTok(u.SessionTokens)
+	if u.SessionLimit > 0 {
+		usageLine = fmt.Sprintf("%s (%s / %s)", fmtPct(u.SessionRatio), fmtTok(u.SessionTokens), fmtTok(u.SessionLimit))
+	}
+	if u.SessionEndsAt != nil {
+		usageLine += fmt.Sprintf(" — ブロック終了: %s", u.SessionEndsAt.In(jst).Format("2006-01-02T15:04:05+09:00"))
+	}
+	fmt.Fprintf(&sb, "- 使用率: %s\n\n", usageLine)
+
+	b := u.SessionBreakdown
+	sb.WriteString("**トークン内訳**\n\n")
+	sb.WriteString("| input | output | cache_creation | cache_read |\n")
+	sb.WriteString("|-------|--------|----------------|------------|\n")
+	fmt.Fprintf(&sb, "| %s | %s | %s | %s |\n\n", fmtTok(b.Input), fmtTok(b.Output), fmtTok(b.CacheCreation), fmtTok(b.CacheRead))
+	return sb.String()
+}
+
+func buildWeekly(u *service.UsageResult, modelBreakdown map[string]int) string {
+	var sb strings.Builder
+	sb.WriteString("### 週次使用量\n\n")
+
+	allLine := fmtTok(u.WeeklyTokens)
+	if u.WeeklyLimit > 0 {
+		allLine = fmt.Sprintf("%s (%s / %s)", fmtPct(u.WeeklyRatio), fmtTok(u.WeeklyTokens), fmtTok(u.WeeklyLimit))
+	}
+	sonnetLine := fmtTok(u.WeeklySonnetTokens)
+	if u.WeeklySonnetLimit > 0 {
+		sonnetLine = fmt.Sprintf("%s (%s / %s)", fmtPct(u.WeeklySonnetRatio), fmtTok(u.WeeklySonnetTokens), fmtTok(u.WeeklySonnetLimit))
+	}
+	resetsAt := u.WeeklyResetsAt.In(jst).Format("2006-01-02T15:04:05+09:00")
+
+	fmt.Fprintf(&sb, "- All: %s\n", allLine)
+	fmt.Fprintf(&sb, "- Sonnet: %s\n", sonnetLine)
+	fmt.Fprintf(&sb, "- リセット: %s\n\n", resetsAt)
+
+	if len(modelBreakdown) > 0 {
+		sb.WriteString("**週次モデル別内訳**\n\n")
+		sb.WriteString("| モデル | トークン |\n")
+		sb.WriteString("|--------|----------|\n")
+		models := make([]string, 0, len(modelBreakdown))
+		for m := range modelBreakdown {
+			models = append(models, m)
+		}
+		sort.Slice(models, func(i, j int) bool {
+			return modelBreakdown[models[i]] > modelBreakdown[models[j]]
+		})
+		for _, m := range models {
+			fmt.Fprintf(&sb, "| %s | %s |\n", m, fmtTok(modelBreakdown[m]))
+		}
+		sb.WriteString("\n")
+	}
+	return sb.String()
+}
+
+func buildBlocks(bs []blocks.Block) string {
+	if len(bs) == 0 {
+		return ""
+	}
+	var sb strings.Builder
+	sb.WriteString("### 直近ブロック一覧 (直近7日)\n\n")
+	sb.WriteString("| 開始 (JST) | 終了 (JST) | トークン |\n")
+	sb.WriteString("|------------|------------|----------|\n")
+	for _, b := range bs {
+		end := b.EndTime.In(jst).Format("2006-01-02 15:04")
+		if b.IsActive {
+			end = "進行中"
+		}
+		fmt.Fprintf(&sb, "| %s | %s | %s |\n",
+			b.StartTime.In(jst).Format("2006-01-02 15:04"),
+			end,
+			fmtTok(b.TotalTokens),
+		)
+	}
+	sb.WriteString("\n")
+	return sb.String()
+}
+
+func buildMonthly(m *MonthlyData) string {
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "### 前月総括 (%s)\n\n", m.Label)
+	fmt.Fprintf(&sb, "**月間トータル**: %s\n\n", fmtTok(m.TotalTokens))
+	sb.WriteString("**モデル別内訳**\n\n")
+	sb.WriteString("| モデル | トークン |\n")
+	sb.WriteString("|--------|----------|\n")
+	if len(m.ByModel) == 0 {
+		sb.WriteString("| (データなし) | — |\n")
+	} else {
+		models := make([]string, 0, len(m.ByModel))
+		for k := range m.ByModel {
+			models = append(models, k)
+		}
+		sort.Slice(models, func(i, j int) bool {
+			return m.ByModel[models[i]] > m.ByModel[models[j]]
+		})
+		for _, k := range models {
+			fmt.Fprintf(&sb, "| %s | %s |\n", k, fmtTok(m.ByModel[k]))
+		}
+	}
+	sb.WriteString("\n")
+	return sb.String()
+}
+
+func fmtTok(n int) string {
+	if n >= 1_000_000 {
+		return fmt.Sprintf("%.0fM", float64(n)/1_000_000)
+	}
+	if n >= 1_000 {
+		return fmt.Sprintf("%.0fk", float64(n)/1_000)
+	}
+	return fmt.Sprintf("%d", n)
+}
+
+func fmtPct(ratio float64) string {
+	return fmt.Sprintf("%.0f%%", ratio*100)
+}

--- a/internal/report/builder_test.go
+++ b/internal/report/builder_test.go
@@ -1,0 +1,174 @@
+package report_test
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/rengotaku/claude-usage-tracker/internal/blocks"
+	"github.com/rengotaku/claude-usage-tracker/internal/report"
+	"github.com/rengotaku/claude-usage-tracker/internal/service"
+)
+
+var jst = time.FixedZone("JST", 9*60*60)
+
+func fixedTime(year, month, day, hour int) time.Time {
+	return time.Date(year, time.Month(month), day, hour, 0, 0, 0, jst)
+}
+
+func TestBuild_ContainsHeader(t *testing.T) {
+	now := fixedTime(2026, 4, 27, 10)
+	input := report.Input{
+		Now:    now,
+		OSType: "linux",
+		Usage:  &service.UsageResult{},
+	}
+	got := report.Build(input)
+	if !strings.Contains(got, "週次レポート") {
+		t.Errorf("expected header '週次レポート', got: %s", got)
+	}
+	if !strings.Contains(got, "linux") {
+		t.Errorf("expected OSType 'linux' in report, got: %s", got)
+	}
+	if !strings.Contains(got, "2026-04-27") {
+		t.Errorf("expected date '2026-04-27' in report, got: %s", got)
+	}
+}
+
+func TestBuild_SessionSection(t *testing.T) {
+	now := fixedTime(2026, 4, 27, 10)
+	sessionEnd := fixedTime(2026, 4, 27, 12)
+	input := report.Input{
+		Now:    now,
+		OSType: "linux",
+		Usage: &service.UsageResult{
+			SessionTokens: 1_500_000,
+			SessionLimit:  88_000,
+			SessionRatio:  0.75,
+			SessionEndsAt: &sessionEnd,
+			SessionBreakdown: blocks.TokenBreakdown{
+				Input:         500_000,
+				Output:        300_000,
+				CacheCreation: 400_000,
+				CacheRead:     300_000,
+			},
+		},
+	}
+	got := report.Build(input)
+	if !strings.Contains(got, "セッション") {
+		t.Errorf("expected session section, got: %s", got)
+	}
+	if !strings.Contains(got, "75%") {
+		t.Errorf("expected 75%%, got: %s", got)
+	}
+}
+
+func TestBuild_WeeklySection(t *testing.T) {
+	now := fixedTime(2026, 4, 27, 10)
+	resetsAt := fixedTime(2026, 4, 28, 9)
+	input := report.Input{
+		Now:    now,
+		OSType: "linux",
+		Usage: &service.UsageResult{
+			WeeklyTokens:       310_000_000,
+			WeeklyLimit:        1_000_000_000,
+			WeeklyRatio:        0.31,
+			WeeklySonnetTokens: 280_000_000,
+			WeeklySonnetLimit:  800_000_000,
+			WeeklySonnetRatio:  0.35,
+			WeeklyResetsAt:     resetsAt,
+		},
+		ModelBreakdown: map[string]int{
+			"Sonnet": 280_000_000,
+			"Opus":   30_000_000,
+		},
+	}
+	got := report.Build(input)
+	if !strings.Contains(got, "週次使用量") {
+		t.Errorf("expected weekly section, got: %s", got)
+	}
+	if !strings.Contains(got, "31%") {
+		t.Errorf("expected 31%%, got: %s", got)
+	}
+	if !strings.Contains(got, "Sonnet") {
+		t.Errorf("expected Sonnet in model breakdown, got: %s", got)
+	}
+}
+
+func TestBuild_RecentBlocks(t *testing.T) {
+	now := fixedTime(2026, 4, 27, 10)
+	blockStart := fixedTime(2026, 4, 26, 8)
+	blockEnd := fixedTime(2026, 4, 26, 13)
+	input := report.Input{
+		Now:    now,
+		OSType: "linux",
+		Usage:  &service.UsageResult{},
+		RecentBlocks: []blocks.Block{
+			{
+				StartTime:   blockStart,
+				EndTime:     blockEnd,
+				TotalTokens: 2_000_000,
+			},
+		},
+	}
+	got := report.Build(input)
+	if !strings.Contains(got, "直近ブロック") {
+		t.Errorf("expected recent blocks section, got: %s", got)
+	}
+	if !strings.Contains(got, "2M") {
+		t.Errorf("expected 2M tokens in blocks, got: %s", got)
+	}
+}
+
+func TestBuild_NoRecentBlocks_SkipsSection(t *testing.T) {
+	now := fixedTime(2026, 4, 27, 10)
+	input := report.Input{
+		Now:    now,
+		OSType: "mac",
+		Usage:  &service.UsageResult{},
+	}
+	got := report.Build(input)
+	if strings.Contains(got, "直近ブロック") {
+		t.Errorf("expected no recent blocks section when empty, got: %s", got)
+	}
+}
+
+func TestBuild_MonthlySummary(t *testing.T) {
+	now := fixedTime(2026, 4, 27, 10)
+	input := report.Input{
+		Now:    now,
+		OSType: "linux",
+		Usage:  &service.UsageResult{},
+		Monthly: &report.MonthlyData{
+			Label:       "2026-03",
+			TotalTokens: 5_000_000,
+			ByModel: map[string]int{
+				"Sonnet": 4_000_000,
+				"Haiku":  1_000_000,
+			},
+		},
+	}
+	got := report.Build(input)
+	if !strings.Contains(got, "前月総括") {
+		t.Errorf("expected monthly section, got: %s", got)
+	}
+	if !strings.Contains(got, "2026-03") {
+		t.Errorf("expected label 2026-03, got: %s", got)
+	}
+	if !strings.Contains(got, "5M") {
+		t.Errorf("expected 5M total tokens, got: %s", got)
+	}
+}
+
+func TestBuild_NoMonthly_SkipsSection(t *testing.T) {
+	now := fixedTime(2026, 4, 27, 10)
+	input := report.Input{
+		Now:    now,
+		OSType: "linux",
+		Usage:  &service.UsageResult{},
+	}
+	got := report.Build(input)
+	if strings.Contains(got, "前月総括") {
+		t.Errorf("expected no monthly section when nil, got: %s", got)
+	}
+}

--- a/internal/report/github.go
+++ b/internal/report/github.go
@@ -1,0 +1,58 @@
+package report
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+const (
+	RepoOwner    = "rengotaku"
+	RepoName     = "claude-usage-tracker"
+	DiscussionNum = 34
+)
+
+// GetDiscussionID resolves the GraphQL node ID for a GitHub discussion number.
+func GetDiscussionID(owner, repo string, num int) (string, error) {
+	query := fmt.Sprintf(
+		`query { repository(owner: "%s", name: "%s") { discussion(number: %d) { id } } }`,
+		owner, repo, num,
+	)
+	out, err := ghRun("api", "graphql", "-f", "query="+query, "--jq", ".data.repository.discussion.id")
+	if err != nil {
+		return "", err
+	}
+	id := strings.TrimSpace(out)
+	if id == "" || id == "null" {
+		return "", fmt.Errorf("discussion #%d not found in %s/%s", num, owner, repo)
+	}
+	return id, nil
+}
+
+// PostComment adds a comment to a GitHub discussion and returns the comment URL.
+func PostComment(discussionID, body string) (string, error) {
+	mutation := `mutation($id: ID!, $body: String!) { addDiscussionComment(input: {discussionId: $id, body: $body}) { comment { url } } }`
+	out, err := ghRun(
+		"api", "graphql",
+		"-f", "query="+mutation,
+		"-f", "id="+discussionID,
+		"-f", "body="+body,
+		"--jq", ".data.addDiscussionComment.comment.url",
+	)
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(out), nil
+}
+
+func ghRun(args ...string) (string, error) {
+	cmd := exec.Command("gh", args...)
+	out, err := cmd.Output()
+	if err != nil {
+		if ee, ok := err.(*exec.ExitError); ok {
+			return "", fmt.Errorf("gh %s: %s", args[0], strings.TrimSpace(string(ee.Stderr)))
+		}
+		return "", fmt.Errorf("gh %s: %w", args[0], err)
+	}
+	return string(out), nil
+}

--- a/internal/report/monthly.go
+++ b/internal/report/monthly.go
@@ -1,0 +1,73 @@
+package report
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/rengotaku/claude-usage-tracker/internal/jsonl"
+)
+
+// MonthlyData holds aggregated stats for a previous month.
+type MonthlyData struct {
+	Label       string
+	TotalTokens int
+	ByModel     map[string]int
+}
+
+// ComputeMonthly returns monthly summary for the previous month if now is within the first 7 days
+// of the month; otherwise returns nil.
+func ComputeMonthly(entries []jsonl.UsageEntry, now time.Time) *MonthlyData {
+	if now.Day() > 7 {
+		return nil
+	}
+
+	firstOfMonth := time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, time.UTC)
+	prevEnd := firstOfMonth
+	var prevStart time.Time
+	if firstOfMonth.Month() == time.January {
+		prevStart = time.Date(firstOfMonth.Year()-1, time.December, 1, 0, 0, 0, 0, time.UTC)
+	} else {
+		prevStart = time.Date(firstOfMonth.Year(), firstOfMonth.Month()-1, 1, 0, 0, 0, 0, time.UTC)
+	}
+
+	label := fmt.Sprintf("%d-%02d", prevStart.Year(), prevStart.Month())
+	byModel := map[string]int{}
+	total := 0
+
+	for _, e := range entries {
+		ts := e.Timestamp.UTC()
+		if ts.Before(prevStart) || !ts.Before(prevEnd) {
+			continue
+		}
+		t := TotalTokens(e)
+		total += t
+		byModel[ClassifyModel(e.Model)] += t
+	}
+
+	return &MonthlyData{
+		Label:       label,
+		TotalTokens: total,
+		ByModel:     byModel,
+	}
+}
+
+// ClassifyModel maps a raw model identifier to a display category.
+func ClassifyModel(model string) string {
+	m := strings.ToLower(model)
+	switch {
+	case strings.Contains(m, "sonnet"):
+		return "Sonnet"
+	case strings.Contains(m, "opus"):
+		return "Opus"
+	case strings.Contains(m, "haiku"):
+		return "Haiku"
+	default:
+		return "Other"
+	}
+}
+
+// TotalTokens returns the sum of all token types in a UsageEntry.
+func TotalTokens(e jsonl.UsageEntry) int {
+	return e.InputTokens + e.OutputTokens + e.CacheCreationInputTokens + e.CacheReadInputTokens
+}

--- a/internal/report/monthly_test.go
+++ b/internal/report/monthly_test.go
@@ -1,0 +1,111 @@
+package report_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/rengotaku/claude-usage-tracker/internal/jsonl"
+	"github.com/rengotaku/claude-usage-tracker/internal/report"
+)
+
+func TestComputeMonthly_ReturnsNilOutsideFirstWeek(t *testing.T) {
+	now := fixedTime(2026, 4, 27, 10) // day 27 — not first week
+	got := report.ComputeMonthly(nil, now)
+	if got != nil {
+		t.Errorf("expected nil outside first week, got %+v", got)
+	}
+}
+
+func TestComputeMonthly_ReturnsDataInFirstWeek(t *testing.T) {
+	now := fixedTime(2026, 5, 3, 10) // day 3 — first week
+	entries := []jsonl.UsageEntry{
+		{
+			Timestamp:    time.Date(2026, 4, 15, 0, 0, 0, 0, time.UTC),
+			Model:        "claude-sonnet-4-6",
+			InputTokens:  1_000_000,
+			OutputTokens: 500_000,
+		},
+		{
+			Timestamp:    time.Date(2026, 4, 20, 0, 0, 0, 0, time.UTC),
+			Model:        "claude-opus-4-7",
+			InputTokens:  200_000,
+			OutputTokens: 100_000,
+		},
+	}
+	got := report.ComputeMonthly(entries, now)
+	if got == nil {
+		t.Fatal("expected monthly data in first week, got nil")
+	}
+	if got.Label != "2026-04" {
+		t.Errorf("expected label 2026-04, got %s", got.Label)
+	}
+	if got.TotalTokens != 1_800_000 {
+		t.Errorf("expected 1800000 total tokens, got %d", got.TotalTokens)
+	}
+	if got.ByModel["Sonnet"] != 1_500_000 {
+		t.Errorf("expected 1500000 for Sonnet, got %d", got.ByModel["Sonnet"])
+	}
+	if got.ByModel["Opus"] != 300_000 {
+		t.Errorf("expected 300000 for Opus, got %d", got.ByModel["Opus"])
+	}
+}
+
+func TestComputeMonthly_ExcludesOutOfRangeEntries(t *testing.T) {
+	now := fixedTime(2026, 5, 1, 10) // day 1 — first week
+	entries := []jsonl.UsageEntry{
+		{
+			Timestamp:   time.Date(2026, 3, 15, 0, 0, 0, 0, time.UTC), // too old
+			Model:       "claude-sonnet-4-6",
+			InputTokens: 999_999,
+		},
+		{
+			Timestamp:   time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC), // current month — excluded
+			Model:       "claude-sonnet-4-6",
+			InputTokens: 999_999,
+		},
+		{
+			Timestamp:   time.Date(2026, 4, 30, 0, 0, 0, 0, time.UTC), // in prev month
+			Model:       "claude-haiku-4-5",
+			InputTokens: 100_000,
+		},
+	}
+	got := report.ComputeMonthly(entries, now)
+	if got == nil {
+		t.Fatal("expected monthly data, got nil")
+	}
+	if got.TotalTokens != 100_000 {
+		t.Errorf("expected 100000, got %d", got.TotalTokens)
+	}
+}
+
+func TestComputeMonthly_ZeroEntriesInFirstWeek(t *testing.T) {
+	now := fixedTime(2026, 5, 3, 10)
+	got := report.ComputeMonthly(nil, now)
+	if got == nil {
+		t.Fatal("expected MonthlyData even with no entries, got nil")
+	}
+	if got.TotalTokens != 0 {
+		t.Errorf("expected 0 total tokens, got %d", got.TotalTokens)
+	}
+	if len(got.ByModel) != 0 {
+		t.Errorf("expected empty ByModel, got %v", got.ByModel)
+	}
+}
+
+func TestComputeMonthly_JanuaryPrevMonth(t *testing.T) {
+	now := fixedTime(2026, 1, 5, 10) // January first week — prev month is December 2025
+	entries := []jsonl.UsageEntry{
+		{
+			Timestamp:   time.Date(2025, 12, 15, 0, 0, 0, 0, time.UTC),
+			Model:       "claude-sonnet-4-6",
+			InputTokens: 500_000,
+		},
+	}
+	got := report.ComputeMonthly(entries, now)
+	if got == nil {
+		t.Fatal("expected monthly data, got nil")
+	}
+	if got.Label != "2025-12" {
+		t.Errorf("expected label 2025-12, got %s", got.Label)
+	}
+}

--- a/internal/service/usage.go
+++ b/internal/service/usage.go
@@ -87,6 +87,7 @@ type UsageResult struct {
 	WeeklySonnetTokens  int
 	WeeklySonnetLimit   int
 	WeeklySonnetRatio   float64
+	WeeklyStartsAt      time.Time
 	WeeklyResetsAt      time.Time
 	WeeklyModelBreakdown map[string]blocks.TokenBreakdown // per-model token breakdown for current week
 }
@@ -105,6 +106,7 @@ func Compute(cfg Config) (*UsageResult, error) {
 		SessionLimit:         cfg.SessionLimit,
 		WeeklyLimit:          cfg.WeeklyLimit,
 		WeeklySonnetLimit:    cfg.WeeklySonnetLimit,
+		WeeklyStartsAt:       lastWeeklyReset(cfg.WeeklyResetDay, cfg.WeeklyResetHour),
 		WeeklyResetsAt:       nextWeeklyReset(cfg.WeeklyResetDay, cfg.WeeklyResetHour),
 		WeeklyModelBreakdown: make(map[string]blocks.TokenBreakdown),
 	}


### PR DESCRIPTION
## 概要

Issue #39 の実装。`scripts/report_usage.py`（Python）を Go に書き直し、`claude-usage-tracker-report` バイナリとして提供する。

## 背景

- コードベース全体が Go であるため Python スクリプトは統一感に欠ける
- Python 版では JSONL パース・重複排除ロジックを再実装したためバグが発生した（PR #38 で修正済み）
- Go 版では `internal/jsonl.Parse` / `blocks.Build` / `service.Compute` を直接利用するため同一ロジックが保証される

## 変更内容

### 新規ファイル

| ファイル | 説明 |
|----------|------|
| `cmd/report/main.go` | エントリポイント (`--dry-run` / `--force`) |
| `internal/report/builder.go` | Markdown レポート生成ロジック |
| `internal/report/monthly.go` | 前月総括集計ロジック (`ClassifyModel` / `TotalTokens` エクスポート) |
| `internal/report/github.go` | Discussion へのコメント投稿 (`gh` CLI 経由) |
| `internal/report/builder_test.go` | builder のユニットテスト (7 ケース) |
| `internal/report/monthly_test.go` | monthly のユニットテスト (5 ケース) |
| `deploy/systemd/claude-usage-report.service` | systemd サービスユニット |
| `deploy/systemd/claude-usage-report.timer` | systemd タイマーユニット (毎週月曜 09:00 JST) |
| `deploy/launchd/com.user.claude-usage-report.plist` | launchd plist (macOS) |

### 更新ファイル

| ファイル | 変更内容 |
|----------|----------|
| `deploy/systemd/install.sh` | `claude-usage-tracker-report` バイナリのビルド・インストール追加 |
| `deploy/launchd/install.sh` | 同上 (macOS) |
| `internal/service/usage.go` | `UsageResult` に `WeeklyStartsAt` フィールドを追加 |

## report コマンドの動作

- `service.Compute` でセッション・週次データを取得
- `jsonl.Parse` + `WeeklyStartsAt` フィルタでモデル別週次内訳を集計
- `blocks.Build` で直近7日のブロック一覧を生成
- 月の第1週 (1〜7日) に実行した場合、前月総括セクションを付与
- 重複投稿制御: `~/.local/share/claude-usage-tracker/last-usage-report.txt` と比較し同一なら skip (`--force` で強制)
- `gh api graphql` で Discussion #34 にコメント投稿

## Python 版との比較

| 項目 | Python 版 (PR #38) | Go 版 (本 PR) |
|------|-----------------|-------|
| JSONL パース | 再実装（バグあり→修正） | `internal/jsonl.Parse` を直接利用 |
| 重複排除 | 手動実装が必要だった | `jsonl.Parse` が保証 |
| 週次開始時刻 | `resets_at - 7日` で近似 | `WeeklyStartsAt` (service と完全同一ロジック) |
| 直近ブロック | SQLite クエリ | `blocks.Build` で正確に再現 |
| 依存 | `python3`, `gh` | `gh` のみ |

## Linux での動作確認済み ✅

- `go run ./cmd/report -- --dry-run` でレポートが stdout に正常出力
- ユニットテスト 12 ケース全 PASS (`go test ./internal/report/...`)

## macOS での確認事項 (要手動確認)

macOS 環境での動作は未確認。以下を確認してほしい。

- [ ] `bash deploy/launchd/install.sh` が完了し、plist が `~/Library/LaunchAgents/` に配置される
- [ ] `launchctl list com.user.claude-usage-report` でジョブが登録されていることを確認
- [ ] `claude-usage-tracker-report --dry-run` を実行し、レポートが stdout に出力される
  - `runtime.GOOS == darwin` のため **実行ホスト: mac** と表示されることを確認
- [ ] `claude-usage-tracker-report --force` で Discussion #34 への投稿が成功する
- [ ] ログが `~/.local/share/claude-usage-tracker/report.log` に出力される

## 関連

- Closes #39
- 参照: PR #38 (Python 版の動作確認済み)

