### PR TITLE
refactor: TokenBreakdown.Add で UsageEntry の加算を共通化

### DIFF
--- a/internal/blocks/blocks.go
+++ b/internal/blocks/blocks.go
@@ -23,6 +23,16 @@ func (t TokenBreakdown) Total() int {
 	return t.Input + t.Output + t.CacheCreation + t.CacheRead
 }
 
+// Add returns a new TokenBreakdown with the entry's tokens added.
+func (t TokenBreakdown) Add(e jsonl.UsageEntry) TokenBreakdown {
+	return TokenBreakdown{
+		Input:         t.Input + e.InputTokens,
+		Output:        t.Output + e.OutputTokens,
+		CacheCreation: t.CacheCreation + e.CacheCreationInputTokens,
+		CacheRead:     t.CacheRead + e.CacheReadInputTokens,
+	}
+}
+
 // Block represents a 5-hour billing period.
 type Block struct {
 	StartTime      time.Time
@@ -61,18 +71,10 @@ func Build(entries []jsonl.UsageEntry) []Block {
 			current = &blocks[len(blocks)-1]
 		}
 		current.TotalTokens += e.TotalTokens()
-		current.Tokens.Input += e.InputTokens
-		current.Tokens.Output += e.OutputTokens
-		current.Tokens.CacheCreation += e.CacheCreationInputTokens
-		current.Tokens.CacheRead += e.CacheReadInputTokens
+		current.Tokens = current.Tokens.Add(e)
 		current.EntryCount++
 		if e.Model != "" {
-			mb := current.ModelBreakdown[e.Model]
-			mb.Input += e.InputTokens
-			mb.Output += e.OutputTokens
-			mb.CacheCreation += e.CacheCreationInputTokens
-			mb.CacheRead += e.CacheReadInputTokens
-			current.ModelBreakdown[e.Model] = mb
+			current.ModelBreakdown[e.Model] = current.ModelBreakdown[e.Model].Add(e)
 		}
 	}
 

--- a/internal/service/usage.go
+++ b/internal/service/usage.go
@@ -150,12 +150,7 @@ func Compute(cfg Config) (*UsageResult, error) {
 			result.WeeklySonnetTokens += t
 		}
 		if e.Model != "" {
-			mb := result.WeeklyModelBreakdown[e.Model]
-			mb.Input += e.InputTokens
-			mb.Output += e.OutputTokens
-			mb.CacheCreation += e.CacheCreationInputTokens
-			mb.CacheRead += e.CacheReadInputTokens
-			result.WeeklyModelBreakdown[e.Model] = mb
+			result.WeeklyModelBreakdown[e.Model] = result.WeeklyModelBreakdown[e.Model].Add(e)
 		}
 	}
 	if cfg.WeeklyLimit > 0 {


### PR DESCRIPTION
## Summary
- \`blocks.TokenBreakdown\` にイミュータブルな \`Add(e jsonl.UsageEntry) TokenBreakdown\` メソッドを追加
- \`blocks.Build\` (block 全体 / ModelBreakdown) と \`service.Compute\` (WeeklyModelBreakdown) の 3 箇所で重複していた加算ロジックを \`Add\` 呼び出しに置換
- \`Add\` のユニットテストを追加（通常加算・ゼロ値レシーバ・レシーバ非破壊性）

closes #45

## Test plan
- [x] \`go build ./...\`
- [x] \`go test ./...\`（既存テスト含めパス）
- [x] 振る舞いに変化がないこと（純粋なロジック抽出）