### PR TITLE
refactor: JST タイムゾーン定義の重複を internal/tz パッケージに集約

### DIFF
--- a/cmd/current/main.go
+++ b/cmd/current/main.go
@@ -12,9 +12,8 @@ import (
 	"github.com/rengotaku/claude-usage-tracker/internal/cache"
 	"github.com/rengotaku/claude-usage-tracker/internal/config"
 	"github.com/rengotaku/claude-usage-tracker/internal/service"
+	"github.com/rengotaku/claude-usage-tracker/internal/tz"
 )
-
-var jst = time.FixedZone("JST", 9*60*60)
 
 type tokenBreakdownJSON struct {
 	Input         int `json:"input"`
@@ -108,7 +107,7 @@ func main() {
 		out.Session.Limit = result.SessionLimit
 		out.Session.Ratio = result.SessionRatio
 		if result.SessionEndsAt != nil {
-			out.Session.EndsAt = result.SessionEndsAt.In(jst).Format("2006-01-02T15:04:05+09:00")
+			out.Session.EndsAt = result.SessionEndsAt.In(tz.JST).Format("2006-01-02T15:04:05+09:00")
 		}
 		out.Weekly.TokensUsed = result.WeeklyTokens
 		out.Weekly.Limit = result.WeeklyLimit
@@ -116,7 +115,7 @@ func main() {
 		out.Weekly.SonnetTokens = result.WeeklySonnetTokens
 		out.Weekly.SonnetLimit = result.WeeklySonnetLimit
 		out.Weekly.SonnetRatio = result.WeeklySonnetRatio
-		out.Weekly.ResetsAt = result.WeeklyResetsAt.In(jst).Format("2006-01-02T15:04:05+09:00")
+		out.Weekly.ResetsAt = result.WeeklyResetsAt.In(tz.JST).Format("2006-01-02T15:04:05+09:00")
 		if len(result.WeeklyModelBreakdown) > 0 {
 			out.Weekly.ModelBreakdown = make(map[string]tokenBreakdownJSON, len(result.WeeklyModelBreakdown))
 			for model, bd := range result.WeeklyModelBreakdown {
@@ -138,7 +137,7 @@ func main() {
 		return
 	}
 
-	resetsAt := result.WeeklyResetsAt.In(jst).Format("Jan 2, 3pm")
+	resetsAt := result.WeeklyResetsAt.In(tz.JST).Format("Jan 2, 3pm")
 	fmt.Printf("Current session   %s\n", sessionLine(result))
 	b := result.SessionBreakdown
 	fmt.Printf("  input %-8s  output %-8s  cache_creation %-8s  cache_read %s\n",
@@ -163,7 +162,7 @@ func main() {
 func sessionLine(r *service.UsageResult) string {
 	endsAt := ""
 	if r.SessionEndsAt != nil {
-		endsAt = ", resets " + r.SessionEndsAt.In(jst).Format("3pm (Asia/Tokyo)")
+		endsAt = ", resets " + r.SessionEndsAt.In(tz.JST).Format("3pm (Asia/Tokyo)")
 	}
 	if r.SessionLimit > 0 {
 		pct := r.SessionRatio * 100

--- a/cmd/report/main.go
+++ b/cmd/report/main.go
@@ -13,9 +13,8 @@ import (
 	"github.com/rengotaku/claude-usage-tracker/internal/jsonl"
 	"github.com/rengotaku/claude-usage-tracker/internal/report"
 	"github.com/rengotaku/claude-usage-tracker/internal/service"
+	"github.com/rengotaku/claude-usage-tracker/internal/tz"
 )
-
-var jst = time.FixedZone("JST", 9*60*60)
 
 const lastReportFile = ".local/share/claude-usage-tracker/last-usage-report.txt"
 
@@ -60,7 +59,7 @@ func main() {
 
 	recentBlocks := buildRecentBlocks(entries)
 
-	now := time.Now().In(jst)
+	now := time.Now().In(tz.JST)
 	monthly := report.ComputeMonthly(entries, now)
 
 	osType := "linux"

--- a/internal/report/builder.go
+++ b/internal/report/builder.go
@@ -8,9 +8,8 @@ import (
 
 	"github.com/rengotaku/claude-usage-tracker/internal/blocks"
 	"github.com/rengotaku/claude-usage-tracker/internal/service"
+	"github.com/rengotaku/claude-usage-tracker/internal/tz"
 )
-
-var jst = time.FixedZone("JST", 9*60*60)
 
 // Input holds all data needed to render a weekly usage report.
 type Input struct {
@@ -24,7 +23,7 @@ type Input struct {
 
 // Build renders the Markdown report body.
 func Build(in Input) string {
-	nowStr := in.Now.In(jst).Format("2006-01-02 15:04 JST")
+	nowStr := in.Now.In(tz.JST).Format("2006-01-02 15:04 JST")
 	var sb strings.Builder
 
 	fmt.Fprintf(&sb, "## 週次レポート — %s\n\n", nowStr)
@@ -48,7 +47,7 @@ func buildSession(u *service.UsageResult) string {
 		usageLine = fmt.Sprintf("%s (%s / %s)", fmtPct(u.SessionRatio), fmtTok(u.SessionTokens), fmtTok(u.SessionLimit))
 	}
 	if u.SessionEndsAt != nil {
-		usageLine += fmt.Sprintf(" — ブロック終了: %s", u.SessionEndsAt.In(jst).Format("2006-01-02T15:04:05+09:00"))
+		usageLine += fmt.Sprintf(" — ブロック終了: %s", u.SessionEndsAt.In(tz.JST).Format("2006-01-02T15:04:05+09:00"))
 	}
 	fmt.Fprintf(&sb, "- 使用率: %s\n\n", usageLine)
 
@@ -72,7 +71,7 @@ func buildWeekly(u *service.UsageResult, modelBreakdown map[string]int) string {
 	if u.WeeklySonnetLimit > 0 {
 		sonnetLine = fmt.Sprintf("%s (%s / %s)", fmtPct(u.WeeklySonnetRatio), fmtTok(u.WeeklySonnetTokens), fmtTok(u.WeeklySonnetLimit))
 	}
-	resetsAt := u.WeeklyResetsAt.In(jst).Format("2006-01-02T15:04:05+09:00")
+	resetsAt := u.WeeklyResetsAt.In(tz.JST).Format("2006-01-02T15:04:05+09:00")
 
 	fmt.Fprintf(&sb, "- All: %s\n", allLine)
 	fmt.Fprintf(&sb, "- Sonnet: %s\n", sonnetLine)
@@ -106,12 +105,12 @@ func buildBlocks(bs []blocks.Block) string {
 	sb.WriteString("| 開始 (JST) | 終了 (JST) | トークン |\n")
 	sb.WriteString("|------------|------------|----------|\n")
 	for _, b := range bs {
-		end := b.EndTime.In(jst).Format("2006-01-02 15:04")
+		end := b.EndTime.In(tz.JST).Format("2006-01-02 15:04")
 		if b.IsActive {
 			end = "進行中"
 		}
 		fmt.Fprintf(&sb, "| %s | %s | %s |\n",
-			b.StartTime.In(jst).Format("2006-01-02 15:04"),
+			b.StartTime.In(tz.JST).Format("2006-01-02 15:04"),
 			end,
 			fmtTok(b.TotalTokens),
 		)

--- a/internal/report/builder_test.go
+++ b/internal/report/builder_test.go
@@ -8,12 +8,11 @@ import (
 	"github.com/rengotaku/claude-usage-tracker/internal/blocks"
 	"github.com/rengotaku/claude-usage-tracker/internal/report"
 	"github.com/rengotaku/claude-usage-tracker/internal/service"
+	"github.com/rengotaku/claude-usage-tracker/internal/tz"
 )
 
-var jst = time.FixedZone("JST", 9*60*60)
-
 func fixedTime(year, month, day, hour int) time.Time {
-	return time.Date(year, time.Month(month), day, hour, 0, 0, 0, jst)
+	return time.Date(year, time.Month(month), day, hour, 0, 0, 0, tz.JST)
 }
 
 func TestBuild_ContainsHeader(t *testing.T) {

--- a/internal/server/aggregation.go
+++ b/internal/server/aggregation.go
@@ -5,9 +5,8 @@ import (
 	"time"
 
 	"github.com/rengotaku/claude-usage-tracker/internal/repository"
+	"github.com/rengotaku/claude-usage-tracker/internal/tz"
 )
-
-var jst = time.FixedZone("JST", 9*60*60)
 
 // BlockAgg represents a 5-hour block aggregation derived from snapshots.
 type BlockAgg struct {
@@ -65,7 +64,7 @@ func AggregateDaily(blocks []BlockAgg) []DailyAgg {
 	}
 	byDate := make(map[string]*DailyAgg)
 	for _, b := range blocks {
-		d := b.Start.In(jst).Format("2006-01-02")
+		d := b.Start.In(tz.JST).Format("2006-01-02")
 		agg, ok := byDate[d]
 		if !ok {
 			agg = &DailyAgg{Date: d}

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/rengotaku/claude-usage-tracker/internal/blocks"
 	"github.com/rengotaku/claude-usage-tracker/internal/repository"
+	"github.com/rengotaku/claude-usage-tracker/internal/tz"
 )
 
 // timeFormat for JSON output (JST).
@@ -19,7 +20,7 @@ type errorResponse struct {
 
 // formatJST renders t in JST using jsonTimeFormat.
 func formatJST(t time.Time) string {
-	return t.In(jst).Format(jsonTimeFormat)
+	return t.In(tz.JST).Format(jsonTimeFormat)
 }
 
 // newPeriod builds a periodDTO from a [from, to] pair.
@@ -70,7 +71,7 @@ func parseFlexibleTime(v string, endOfDay bool) (time.Time, error) {
 	if t, err := time.Parse(time.RFC3339, v); err == nil {
 		return t.UTC(), nil
 	}
-	if t, err := time.ParseInLocation("2006-01-02", v, jst); err == nil {
+	if t, err := time.ParseInLocation("2006-01-02", v, tz.JST); err == nil {
 		if endOfDay {
 			t = t.Add(24*time.Hour - time.Second)
 		}

--- a/internal/service/usage.go
+++ b/internal/service/usage.go
@@ -9,9 +9,8 @@ import (
 	"github.com/rengotaku/claude-usage-tracker/internal/config"
 	"github.com/rengotaku/claude-usage-tracker/internal/jsonl"
 	"github.com/rengotaku/claude-usage-tracker/internal/plan"
+	"github.com/rengotaku/claude-usage-tracker/internal/tz"
 )
-
-var jst = time.FixedZone("JST", 9*60*60)
 
 var weekdayNames = map[string]time.Weekday{
 	"sunday": time.Sunday, "monday": time.Monday, "tuesday": time.Tuesday,
@@ -152,9 +151,9 @@ func Compute(cfg Config) (*UsageResult, error) {
 }
 
 func lastWeeklyReset(day time.Weekday, hour int) time.Time {
-	now := time.Now().In(jst)
+	now := time.Now().In(tz.JST)
 	daysSince := (int(now.Weekday()) - int(day) + 7) % 7
-	reset := time.Date(now.Year(), now.Month(), now.Day()-daysSince, hour, 0, 0, 0, jst)
+	reset := time.Date(now.Year(), now.Month(), now.Day()-daysSince, hour, 0, 0, 0, tz.JST)
 	if now.Before(reset) {
 		reset = reset.AddDate(0, 0, -7)
 	}

--- a/internal/tz/tz.go
+++ b/internal/tz/tz.go
@@ -1,0 +1,7 @@
+// Package tz は本プロジェクトで共通利用するタイムゾーン定数を提供する。
+package tz
+
+import "time"
+
+// JST は日本標準時 (UTC+9)。
+var JST = time.FixedZone("JST", 9*60*60)


### PR DESCRIPTION
## Summary

Closes #46

複数パッケージで重複していた \`var jst = time.FixedZone(\"JST\", 9*60*60)\` の定義を、新規パッケージ \`internal/tz\` の \`tz.JST\` に一元化した。

## 変更内容

- 新規 \`internal/tz/tz.go\` を追加し \`tz.JST\` を公開
- 以下 6 ファイルのローカル \`var jst\` を削除し \`tz.JST\` 参照に置換
  - \`cmd/current/main.go\`
  - \`cmd/report/main.go\`
  - \`internal/report/builder.go\`
  - \`internal/report/builder_test.go\`
  - \`internal/server/aggregation.go\`
  - \`internal/service/usage.go\`
- 同 \`internal/server\` パッケージ内で \`jst\` を共有していた \`internal/server/handlers.go\` も \`tz.JST\` を参照するよう更新

## 設計上のポイント

- 値は \`time.FixedZone\` で同じ結果になるため、挙動に変化はない
- 共通ヘルパは \`internal/tz\` という最小単位のパッケージに切り出し、依存方向を一方向に保った（他パッケージが \`tz\` に依存する形）

## Test plan

- [x] \`make build\` 成功
- [x] \`make test\` 成功（\`internal/report\` の既存テスト含めすべて pass）
- [x] \`go vet ./...\` 警告なし
- [ ] CI (GitHub Actions \`test.yml\`) がグリーンになること