### PR TITLE
refactor: UsageEntry.TotalTokens メソッドで重複定義を共通化 (#53)

### DIFF
--- a/cmd/report/main.go
+++ b/cmd/report/main.go
@@ -119,7 +119,7 @@ func computeModelBreakdown(entries []jsonl.UsageEntry, weekStart time.Time) map[
 		if e.Timestamp.Before(weekStart) {
 			continue
 		}
-		byModel[report.ClassifyModel(e.Model)] += report.TotalTokens(e)
+		byModel[report.ClassifyModel(e.Model)] += e.TotalTokens()
 	}
 	return byModel
 }

--- a/internal/blocks/blocks.go
+++ b/internal/blocks/blocks.go
@@ -59,7 +59,7 @@ func Build(entries []jsonl.UsageEntry) []Block {
 			blocks = append(blocks, b)
 			current = &blocks[len(blocks)-1]
 		}
-		current.TotalTokens += totalTokens(e)
+		current.TotalTokens += e.TotalTokens()
 		current.Tokens.Input += e.InputTokens
 		current.Tokens.Output += e.OutputTokens
 		current.Tokens.CacheCreation += e.CacheCreationInputTokens
@@ -93,9 +93,4 @@ func ActiveBlock(blocks []Block) *Block {
 		}
 	}
 	return nil
-}
-
-
-func totalTokens(e jsonl.UsageEntry) int {
-	return e.InputTokens + e.OutputTokens + e.CacheCreationInputTokens + e.CacheReadInputTokens
 }

--- a/internal/jsonl/parser.go
+++ b/internal/jsonl/parser.go
@@ -21,6 +21,11 @@ type UsageEntry struct {
 	CacheReadInputTokens     int
 }
 
+// TotalTokens returns the sum of all token types in the entry.
+func (e UsageEntry) TotalTokens() int {
+	return e.InputTokens + e.OutputTokens + e.CacheCreationInputTokens + e.CacheReadInputTokens
+}
+
 type rawEntry struct {
 	Type      string    `json:"type"`
 	UUID      string    `json:"uuid"`

--- a/internal/jsonl/parser_test.go
+++ b/internal/jsonl/parser_test.go
@@ -77,6 +77,37 @@ func TestParse_NonExistentDir(t *testing.T) {
 	}
 }
 
+func TestUsageEntry_TotalTokens(t *testing.T) {
+	tests := []struct {
+		name string
+		e    jsonl.UsageEntry
+		want int
+	}{
+		{
+			name: "all fields set",
+			e: jsonl.UsageEntry{
+				InputTokens:              10,
+				OutputTokens:             20,
+				CacheCreationInputTokens: 100,
+				CacheReadInputTokens:     50,
+			},
+			want: 180,
+		},
+		{
+			name: "zero value",
+			e:    jsonl.UsageEntry{},
+			want: 0,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := tc.e.TotalTokens(); got != tc.want {
+				t.Errorf("TotalTokens: want %d, got %d", tc.want, got)
+			}
+		})
+	}
+}
+
 func TestParse_SkipsMalformedLines(t *testing.T) {
 	// sample.jsonl contains one malformed line; Parse should not return error
 	entries, err := jsonl.Parse("testdata")

--- a/internal/report/monthly.go
+++ b/internal/report/monthly.go
@@ -40,7 +40,7 @@ func ComputeMonthly(entries []jsonl.UsageEntry, now time.Time) *MonthlyData {
 		if ts.Before(prevStart) || !ts.Before(prevEnd) {
 			continue
 		}
-		t := TotalTokens(e)
+		t := e.TotalTokens()
 		total += t
 		byModel[ClassifyModel(e.Model)] += t
 	}
@@ -65,9 +65,4 @@ func ClassifyModel(model string) string {
 	default:
 		return "Other"
 	}
-}
-
-// TotalTokens returns the sum of all token types in a UsageEntry.
-func TotalTokens(e jsonl.UsageEntry) int {
-	return e.InputTokens + e.OutputTokens + e.CacheCreationInputTokens + e.CacheReadInputTokens
 }

--- a/internal/service/usage.go
+++ b/internal/service/usage.go
@@ -127,7 +127,7 @@ func Compute(cfg Config) (*UsageResult, error) {
 		if e.Timestamp.Before(weekStart) {
 			continue
 		}
-		t := totalTokens(e)
+		t := e.TotalTokens()
 		result.WeeklyTokens += t
 		if isSonnet(e.Model) {
 			result.WeeklySonnetTokens += t
@@ -163,10 +163,6 @@ func lastWeeklyReset(day time.Weekday, hour int) time.Time {
 
 func nextWeeklyReset(day time.Weekday, hour int) time.Time {
 	return lastWeeklyReset(day, hour).AddDate(0, 0, 7)
-}
-
-func totalTokens(e jsonl.UsageEntry) int {
-	return e.InputTokens + e.OutputTokens + e.CacheCreationInputTokens + e.CacheReadInputTokens
 }
 
 func isSonnet(model string) bool {


### PR DESCRIPTION
## Summary
- \`UsageEntry\` にメソッド \`TotalTokens()\` を追加し、input/output/cache 4 系統の合計算出ロジックを集約
- \`internal/blocks\` / \`internal/service\` / \`internal/report\` で重複していた \`totalTokens\` / \`TotalTokens\` 関数を削除
- 呼び出し側 (\`cmd/report\`, \`internal/blocks/blocks.go\`, \`internal/service/usage.go\`, \`internal/report/monthly.go\`) を \`e.TotalTokens()\` に置換
- \`internal/jsonl\` にユニットテストを追加（通常値・ゼロ値）

closes #53

## Test plan
- [x] \`go build ./...\`
- [x] \`go test ./...\`（全パッケージパス）
- [x] \`go vet ./...\`
- [x] 振る舞いに変更なし（純粋なロジック抽出）