### PR TITLE
refactor: TokenBreakdown 累積処理と totalTokens の重複を統合

### DIFF
--- a/internal/blocks/blocks.go
+++ b/internal/blocks/blocks.go
@@ -22,6 +22,26 @@ func (t TokenBreakdown) Total() int {
 	return t.Input + t.Output + t.CacheCreation + t.CacheRead
 }
 
+// FromEntry constructs a TokenBreakdown from a single usage entry.
+func FromEntry(e jsonl.UsageEntry) TokenBreakdown {
+	return TokenBreakdown{
+		Input:         e.InputTokens,
+		Output:        e.OutputTokens,
+		CacheCreation: e.CacheCreationInputTokens,
+		CacheRead:     e.CacheReadInputTokens,
+	}
+}
+
+// Add returns the sum of two breakdowns. The receiver is not mutated.
+func (t TokenBreakdown) Add(other TokenBreakdown) TokenBreakdown {
+	return TokenBreakdown{
+		Input:         t.Input + other.Input,
+		Output:        t.Output + other.Output,
+		CacheCreation: t.CacheCreation + other.CacheCreation,
+		CacheRead:     t.CacheRead + other.CacheRead,
+	}
+}
+
 // Block represents a 5-hour billing period.
 type Block struct {
 	StartTime      time.Time
@@ -59,19 +79,12 @@ func Build(entries []jsonl.UsageEntry) []Block {
 			blocks = append(blocks, b)
 			current = &blocks[len(blocks)-1]
 		}
-		current.TotalTokens += totalTokens(e)
-		current.Tokens.Input += e.InputTokens
-		current.Tokens.Output += e.OutputTokens
-		current.Tokens.CacheCreation += e.CacheCreationInputTokens
-		current.Tokens.CacheRead += e.CacheReadInputTokens
+		bd := FromEntry(e)
+		current.TotalTokens += bd.Total()
+		current.Tokens = current.Tokens.Add(bd)
 		current.EntryCount++
 		if e.Model != "" {
-			mb := current.ModelBreakdown[e.Model]
-			mb.Input += e.InputTokens
-			mb.Output += e.OutputTokens
-			mb.CacheCreation += e.CacheCreationInputTokens
-			mb.CacheRead += e.CacheReadInputTokens
-			current.ModelBreakdown[e.Model] = mb
+			current.ModelBreakdown[e.Model] = current.ModelBreakdown[e.Model].Add(bd)
 		}
 	}
 
@@ -93,9 +106,4 @@ func ActiveBlock(blocks []Block) *Block {
 		}
 	}
 	return nil
-}
-
-
-func totalTokens(e jsonl.UsageEntry) int {
-	return e.InputTokens + e.OutputTokens + e.CacheCreationInputTokens + e.CacheReadInputTokens
 }

--- a/internal/service/usage.go
+++ b/internal/service/usage.go
@@ -127,18 +127,14 @@ func Compute(cfg Config) (*UsageResult, error) {
 		if e.Timestamp.Before(weekStart) {
 			continue
 		}
-		t := totalTokens(e)
+		bd := blocks.FromEntry(e)
+		t := bd.Total()
 		result.WeeklyTokens += t
 		if isSonnet(e.Model) {
 			result.WeeklySonnetTokens += t
 		}
 		if e.Model != "" {
-			mb := result.WeeklyModelBreakdown[e.Model]
-			mb.Input += e.InputTokens
-			mb.Output += e.OutputTokens
-			mb.CacheCreation += e.CacheCreationInputTokens
-			mb.CacheRead += e.CacheReadInputTokens
-			result.WeeklyModelBreakdown[e.Model] = mb
+			result.WeeklyModelBreakdown[e.Model] = result.WeeklyModelBreakdown[e.Model].Add(bd)
 		}
 	}
 	if cfg.WeeklyLimit > 0 {
@@ -163,10 +159,6 @@ func lastWeeklyReset(day time.Weekday, hour int) time.Time {
 
 func nextWeeklyReset(day time.Weekday, hour int) time.Time {
 	return lastWeeklyReset(day, hour).AddDate(0, 0, 7)
-}
-
-func totalTokens(e jsonl.UsageEntry) int {
-	return e.InputTokens + e.OutputTokens + e.CacheCreationInputTokens + e.CacheReadInputTokens
 }
 
 func isSonnet(model string) bool {


### PR DESCRIPTION
## 概要

\`internal/blocks\` と \`internal/service\` に重複していたトークン累積パターンと \`totalTokens\` 関数を、\`blocks.TokenBreakdown\` のメソッドへ集約した。

closes #55

## 変更点

- \`blocks.TokenBreakdown\` に以下を追加
  - \`FromEntry(jsonl.UsageEntry) TokenBreakdown\`: エントリから内訳を生成
  - \`Add(other TokenBreakdown) TokenBreakdown\`: 非破壊的な加算（receiver 不変）
- \`blocks.Build\`: 4 行のフィールド加算 × 2 箇所を \`Tokens.Add(bd)\` / \`ModelBreakdown[m].Add(bd)\` に置換
- \`service.Compute\`: 同様に \`WeeklyModelBreakdown[m].Add(bd)\` に置換
- \`internal/blocks/blocks.go\` と \`internal/service/usage.go\` の双方に存在していた \`totalTokens(e)\` を削除し、\`blocks.FromEntry(e).Total()\` で代替

## 設計判断

- 戻り値で新しい \`TokenBreakdown\` を返す不変パターンを採用（CLAUDE.md の Immutability ルールに沿う）
- \`blocks\` パッケージは元々 \`jsonl\` をインポートしているため、\`FromEntry\` を blocks 側に置いても循環依存は発生しない
- 外部仕様（API/CLI 出力）には変更なし

## テスト

- \`make build\`: 成功
- \`make test\`: 全パッケージ pass（既存テストで内訳・合計の網羅は十分）
- \`go vet ./...\`: クリーン