### PR TITLE
refactor: token breakdown JSON DTO を internal/usagejson に集約 (#57)

### DIFF
--- a/cmd/current/main.go
+++ b/cmd/current/main.go
@@ -9,49 +9,33 @@ import (
 	"sort"
 	"time"
 
-	"github.com/rengotaku/claude-usage-tracker/internal/blocks"
 	"github.com/rengotaku/claude-usage-tracker/internal/cache"
 	"github.com/rengotaku/claude-usage-tracker/internal/config"
 	"github.com/rengotaku/claude-usage-tracker/internal/logging"
 	"github.com/rengotaku/claude-usage-tracker/internal/numfmt"
 	"github.com/rengotaku/claude-usage-tracker/internal/service"
 	"github.com/rengotaku/claude-usage-tracker/internal/tz"
+	"github.com/rengotaku/claude-usage-tracker/internal/usagejson"
 )
 
 
-type tokenBreakdownJSON struct {
-	Input         int `json:"input"`
-	Output        int `json:"output"`
-	CacheCreation int `json:"cache_creation"`
-	CacheRead     int `json:"cache_read"`
-}
-
-func newTokenBreakdownJSON(b blocks.TokenBreakdown) tokenBreakdownJSON {
-	return tokenBreakdownJSON{
-		Input:         b.Input,
-		Output:        b.Output,
-		CacheCreation: b.CacheCreation,
-		CacheRead:     b.CacheRead,
-	}
-}
-
 type jsonOutput struct {
 	Session struct {
-		TokensUsed int                `json:"tokens_used"`
-		Breakdown  tokenBreakdownJSON `json:"breakdown"`
-		Limit      int                `json:"limit,omitempty"`
-		Ratio      float64            `json:"ratio,omitempty"`
-		EndsAt     string             `json:"ends_at,omitempty"`
+		TokensUsed int                      `json:"tokens_used"`
+		Breakdown  usagejson.TokenBreakdown `json:"breakdown"`
+		Limit      int                      `json:"limit,omitempty"`
+		Ratio      float64                  `json:"ratio,omitempty"`
+		EndsAt     string                   `json:"ends_at,omitempty"`
 	} `json:"session"`
 	Weekly struct {
-		TokensUsed     int                            `json:"tokens_used"`
-		Limit          int                            `json:"limit,omitempty"`
-		Ratio          float64                        `json:"ratio,omitempty"`
-		SonnetTokens   int                            `json:"sonnet_tokens_used"`
-		SonnetLimit    int                            `json:"sonnet_limit,omitempty"`
-		SonnetRatio    float64                        `json:"sonnet_ratio,omitempty"`
-		ResetsAt       string                         `json:"resets_at"`
-		ModelBreakdown map[string]tokenBreakdownJSON  `json:"model_breakdown,omitempty"`
+		TokensUsed     int                                 `json:"tokens_used"`
+		Limit          int                                 `json:"limit,omitempty"`
+		Ratio          float64                             `json:"ratio,omitempty"`
+		SonnetTokens   int                                 `json:"sonnet_tokens_used"`
+		SonnetLimit    int                                 `json:"sonnet_limit,omitempty"`
+		SonnetRatio    float64                             `json:"sonnet_ratio,omitempty"`
+		ResetsAt       string                              `json:"resets_at"`
+		ModelBreakdown map[string]usagejson.TokenBreakdown `json:"model_breakdown,omitempty"`
 	} `json:"weekly"`
 }
 
@@ -105,7 +89,7 @@ func main() {
 	if jsonFlag {
 		out := jsonOutput{}
 		out.Session.TokensUsed = result.SessionTokens
-		out.Session.Breakdown = newTokenBreakdownJSON(result.SessionBreakdown)
+		out.Session.Breakdown = usagejson.FromBlocks(result.SessionBreakdown)
 		out.Session.Limit = result.SessionLimit
 		out.Session.Ratio = result.SessionRatio
 		if result.SessionEndsAt != nil {
@@ -118,12 +102,7 @@ func main() {
 		out.Weekly.SonnetLimit = result.WeeklySonnetLimit
 		out.Weekly.SonnetRatio = result.WeeklySonnetRatio
 		out.Weekly.ResetsAt = result.WeeklyResetsAt.In(tz.JST).Format(time.RFC3339)
-		if len(result.WeeklyModelBreakdown) > 0 {
-			out.Weekly.ModelBreakdown = make(map[string]tokenBreakdownJSON, len(result.WeeklyModelBreakdown))
-			for model, bd := range result.WeeklyModelBreakdown {
-				out.Weekly.ModelBreakdown[model] = newTokenBreakdownJSON(bd)
-			}
-		}
+		out.Weekly.ModelBreakdown = usagejson.MapFromBlocks(result.WeeklyModelBreakdown)
 
 		enc := json.NewEncoder(os.Stdout)
 		enc.SetIndent("", "  ")

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -6,9 +6,9 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/rengotaku/claude-usage-tracker/internal/blocks"
 	"github.com/rengotaku/claude-usage-tracker/internal/repository"
 	"github.com/rengotaku/claude-usage-tracker/internal/tz"
+	"github.com/rengotaku/claude-usage-tracker/internal/usagejson"
 )
 
 // timeFormat for JSON output (JST).
@@ -26,16 +26,6 @@ func formatJST(t time.Time) string {
 // newPeriod builds a periodDTO from a [from, to] pair.
 func newPeriod(from, to time.Time) periodDTO {
 	return periodDTO{From: formatJST(from), To: formatJST(to)}
-}
-
-// toTokenBreakdown converts a blocks.TokenBreakdown to its DTO form.
-func toTokenBreakdown(b blocks.TokenBreakdown) tokenBreakdown {
-	return tokenBreakdown{
-		Input:         b.Input,
-		Output:        b.Output,
-		CacheCreation: b.CacheCreation,
-		CacheRead:     b.CacheRead,
-	}
 }
 
 // loadRange parses from/to query params and loads snapshots in that range.
@@ -110,23 +100,16 @@ func writeError(w http.ResponseWriter, status int, msg string) {
 
 // --- /usage/snapshots ---
 
-type tokenBreakdown struct {
-	Input         int `json:"input"`
-	Output        int `json:"output"`
-	CacheCreation int `json:"cache_creation"`
-	CacheRead     int `json:"cache_read"`
-}
-
 type snapshotItem struct {
-	TakenAt              string                    `json:"taken_at"`
-	BlockStartedAt       string                    `json:"block_started_at"`
-	BlockEndedAt         string                    `json:"block_ended_at,omitempty"`
-	SessionTokens        int                       `json:"session_tokens"`
-	Tokens               tokenBreakdown            `json:"tokens"`
-	SessionRatio         float64                   `json:"session_ratio"`
-	WeeklyTokens         int                       `json:"weekly_tokens"`
-	WeeklySonnetTokens   int                       `json:"weekly_sonnet_tokens"`
-	WeeklyModelBreakdown map[string]tokenBreakdown `json:"weekly_model_breakdown,omitempty"`
+	TakenAt              string                              `json:"taken_at"`
+	BlockStartedAt       string                              `json:"block_started_at"`
+	BlockEndedAt         string                              `json:"block_ended_at,omitempty"`
+	SessionTokens        int                                 `json:"session_tokens"`
+	Tokens               usagejson.TokenBreakdown            `json:"tokens"`
+	SessionRatio         float64                             `json:"session_ratio"`
+	WeeklyTokens         int                                 `json:"weekly_tokens"`
+	WeeklySonnetTokens   int                                 `json:"weekly_sonnet_tokens"`
+	WeeklyModelBreakdown map[string]usagejson.TokenBreakdown `json:"weekly_model_breakdown,omitempty"`
 }
 
 type snapshotsResponse struct {
@@ -147,19 +130,14 @@ func (h *Handler) Snapshots(w http.ResponseWriter, r *http.Request) {
 	items := make([]snapshotItem, 0, len(snaps))
 	for _, s := range snaps {
 		item := snapshotItem{
-			TakenAt:            formatJST(s.TakenAt),
-			BlockStartedAt:     formatJST(s.BlockStartedAt),
-			SessionTokens:      s.TokensUsed,
-			Tokens:             toTokenBreakdown(s.Tokens),
-			SessionRatio:       s.UsageRatio,
-			WeeklyTokens:       s.WeeklyTokens,
-			WeeklySonnetTokens: s.WeeklySonnetTokens,
-		}
-		if len(s.WeeklyModelBreakdown) > 0 {
-			item.WeeklyModelBreakdown = make(map[string]tokenBreakdown, len(s.WeeklyModelBreakdown))
-			for model, bd := range s.WeeklyModelBreakdown {
-				item.WeeklyModelBreakdown[model] = toTokenBreakdown(bd)
-			}
+			TakenAt:              formatJST(s.TakenAt),
+			BlockStartedAt:       formatJST(s.BlockStartedAt),
+			SessionTokens:        s.TokensUsed,
+			Tokens:               usagejson.FromBlocks(s.Tokens),
+			SessionRatio:         s.UsageRatio,
+			WeeklyTokens:         s.WeeklyTokens,
+			WeeklySonnetTokens:   s.WeeklySonnetTokens,
+			WeeklyModelBreakdown: usagejson.MapFromBlocks(s.WeeklyModelBreakdown),
 		}
 		if s.BlockEndedAt != nil {
 			item.BlockEndedAt = formatJST(*s.BlockEndedAt)

--- a/internal/usagejson/breakdown.go
+++ b/internal/usagejson/breakdown.go
@@ -1,0 +1,41 @@
+// Package usagejson contains JSON DTOs that are shared between the HTTP API
+// (internal/server) and CLI commands (cmd/current). Keeping these in one place
+// avoids drift between API responses and CLI --json output.
+package usagejson
+
+import "github.com/rengotaku/claude-usage-tracker/internal/blocks"
+
+// TokenBreakdown is the JSON wire format for blocks.TokenBreakdown.
+//
+// It is intentionally separate from blocks.TokenBreakdown: the latter is also
+// persisted to SQLite via json.Marshal without struct tags, so adding snake_case
+// tags there would silently break readback of existing rows.
+type TokenBreakdown struct {
+	Input         int `json:"input"`
+	Output        int `json:"output"`
+	CacheCreation int `json:"cache_creation"`
+	CacheRead     int `json:"cache_read"`
+}
+
+// FromBlocks converts a blocks.TokenBreakdown to its JSON DTO form.
+func FromBlocks(b blocks.TokenBreakdown) TokenBreakdown {
+	return TokenBreakdown{
+		Input:         b.Input,
+		Output:        b.Output,
+		CacheCreation: b.CacheCreation,
+		CacheRead:     b.CacheRead,
+	}
+}
+
+// MapFromBlocks converts a per-model breakdown map to its JSON DTO form.
+// Returns nil for empty input so callers can rely on omitempty behavior.
+func MapFromBlocks(m map[string]blocks.TokenBreakdown) map[string]TokenBreakdown {
+	if len(m) == 0 {
+		return nil
+	}
+	out := make(map[string]TokenBreakdown, len(m))
+	for k, v := range m {
+		out[k] = FromBlocks(v)
+	}
+	return out
+}

--- a/internal/usagejson/breakdown_test.go
+++ b/internal/usagejson/breakdown_test.go
@@ -1,0 +1,66 @@
+package usagejson
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+
+	"github.com/rengotaku/claude-usage-tracker/internal/blocks"
+)
+
+func TestFromBlocksMapsAllFields(t *testing.T) {
+	got := FromBlocks(blocks.TokenBreakdown{
+		Input:         1,
+		Output:        2,
+		CacheCreation: 3,
+		CacheRead:     4,
+	})
+	want := TokenBreakdown{Input: 1, Output: 2, CacheCreation: 3, CacheRead: 4}
+	if got != want {
+		t.Fatalf("FromBlocks: got %+v, want %+v", got, want)
+	}
+}
+
+func TestTokenBreakdownJSONKeys(t *testing.T) {
+	b, err := json.Marshal(TokenBreakdown{Input: 10, Output: 20, CacheCreation: 30, CacheRead: 40})
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var raw map[string]int
+	if err := json.Unmarshal(b, &raw); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	want := map[string]int{
+		"input":          10,
+		"output":         20,
+		"cache_creation": 30,
+		"cache_read":     40,
+	}
+	if !reflect.DeepEqual(raw, want) {
+		t.Fatalf("JSON keys: got %v, want %v", raw, want)
+	}
+}
+
+func TestMapFromBlocksReturnsNilForEmpty(t *testing.T) {
+	if got := MapFromBlocks(nil); got != nil {
+		t.Fatalf("nil input: got %v, want nil", got)
+	}
+	if got := MapFromBlocks(map[string]blocks.TokenBreakdown{}); got != nil {
+		t.Fatalf("empty input: got %v, want nil", got)
+	}
+}
+
+func TestMapFromBlocksConvertsEntries(t *testing.T) {
+	in := map[string]blocks.TokenBreakdown{
+		"sonnet": {Input: 1, Output: 2, CacheCreation: 3, CacheRead: 4},
+		"opus":   {Input: 5, Output: 6, CacheCreation: 7, CacheRead: 8},
+	}
+	got := MapFromBlocks(in)
+	want := map[string]TokenBreakdown{
+		"sonnet": {Input: 1, Output: 2, CacheCreation: 3, CacheRead: 4},
+		"opus":   {Input: 5, Output: 6, CacheCreation: 7, CacheRead: 8},
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("MapFromBlocks: got %+v, want %+v", got, want)
+	}
+}


### PR DESCRIPTION
## 背景

Closes #57

`cmd/current/main.go` の `tokenBreakdownJSON` と `internal/server/handlers.go` の `tokenBreakdown` / `toTokenBreakdown` が同一定義になっていた。
それぞれの `WeeklyModelBreakdown` ループも同じ変換を手書きしていた。

## 変更内容

- 新規 `internal/usagejson` パッケージを追加
  - `TokenBreakdown` (snake_case JSON タグ付き)
  - `FromBlocks(blocks.TokenBreakdown)`
  - `MapFromBlocks(map[string]blocks.TokenBreakdown)` (空入力時は nil を返す)
- `cmd/current/main.go` と `internal/server/handlers.go` の重複定義および手書き変換を削除し、共通ヘルパに置き換え
- `internal/usagejson` のユニットテストを追加（フィールドコピー、JSON キー、空入力時の nil 返却）

## 互換性

- API レスポンスのキー (`input` / `output` / `cache_creation` / `cache_read`) は維持
- DB に保存される `model_breakdown` は `blocks.TokenBreakdown` を直接 `json.Marshal` しており JSON タグなしのフィールド名で書き出されている。互換性のため `blocks.TokenBreakdown` には JSON タグを足さず、別 DTO 型として切り出している
- `cmd/current --json` の `weekly.model_breakdown` は空マップでなく未設定（`omitempty`）扱いになる挙動を維持

## 動作確認

- [x] `CGO_ENABLED=0 go build ./...`
- [x] `CGO_ENABLED=0 go test ./...` (新規テスト含む全パッケージ green)
- [x] `go vet ./...`