### PR TITLE
refactor: ComputeMonthly の前月開始日計算を AddDate で簡略化 (#61)

### DIFF
--- a/internal/report/monthly.go
+++ b/internal/report/monthly.go
@@ -23,13 +23,8 @@ func ComputeMonthly(entries []jsonl.UsageEntry, now time.Time) *MonthlyData {
 	}
 
 	firstOfMonth := time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, time.UTC)
+	prevStart := firstOfMonth.AddDate(0, -1, 0)
 	prevEnd := firstOfMonth
-	var prevStart time.Time
-	if firstOfMonth.Month() == time.January {
-		prevStart = time.Date(firstOfMonth.Year()-1, time.December, 1, 0, 0, 0, 0, time.UTC)
-	} else {
-		prevStart = time.Date(firstOfMonth.Year(), firstOfMonth.Month()-1, 1, 0, 0, 0, 0, time.UTC)
-	}
 
 	label := fmt.Sprintf("%d-%02d", prevStart.Year(), prevStart.Month())
 	byModel := map[string]int{}


### PR DESCRIPTION
Closes #61

## 概要

`internal/report/monthly.go` の `ComputeMonthly` で「1月のときだけ前年12月にする」分岐を `time.AddDate(0, -1, 0)` 一行に置き換えた。

```diff
 firstOfMonth := time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, time.UTC)
+prevStart := firstOfMonth.AddDate(0, -1, 0)
 prevEnd := firstOfMonth
-var prevStart time.Time
-if firstOfMonth.Month() == time.January {
-    prevStart = time.Date(firstOfMonth.Year()-1, time.December, 1, 0, 0, 0, 0, time.UTC)
-} else {
-    prevStart = time.Date(firstOfMonth.Year(), firstOfMonth.Month()-1, 1, 0, 0, 0, 0, time.UTC)
-}
```

## 変更点

- `internal/report/monthly.go`: `prevStart` 計算を `AddDate` に置換し、`if firstOfMonth.Month() == time.January` 分岐を削除（5行→1行）

## 振る舞い

不変。`AddDate(0, -1, 0)` は標準ライブラリが年跨ぎを正規化するため、1月→前年12月、それ以外→当年前月 と等価。

## 動作確認

- [x] `go build ./...` がパス
- [x] `go test ./...` がパス
  - `TestComputeMonthly_JanuaryPrevMonth`（1月特殊ケース）含めグリーン
  - `TestComputeMonthly_ReturnsDataInFirstWeek`（5月→4月の通常ケース）含めグリーン
- [ ] CI (test.yml) のパスを確認（PR 作成後）