### PR TITLE
refactor: UsageEntry.TotalTokens() メソッドに集約し3箇所の重複を削除

### DIFF
--- a/cmd/report/main.go
+++ b/cmd/report/main.go
@@ -119,7 +119,7 @@ func computeModelBreakdown(entries []jsonl.UsageEntry, weekStart time.Time) map[
 		if e.Timestamp.Before(weekStart) {
 			continue
 		}
-		byModel[report.ClassifyModel(e.Model)] += report.TotalTokens(e)
+		byModel[report.ClassifyModel(e.Model)] += e.TotalTokens()
 	}
 	return byModel
 }

--- a/internal/blocks/blocks.go
+++ b/internal/blocks/blocks.go
@@ -59,7 +59,7 @@ func Build(entries []jsonl.UsageEntry) []Block {
 			blocks = append(blocks, b)
 			current = &blocks[len(blocks)-1]
 		}
-		current.TotalTokens += totalTokens(e)
+		current.TotalTokens += e.TotalTokens()
 		current.Tokens.Input += e.InputTokens
 		current.Tokens.Output += e.OutputTokens
 		current.Tokens.CacheCreation += e.CacheCreationInputTokens
@@ -93,9 +93,4 @@ func ActiveBlock(blocks []Block) *Block {
 		}
 	}
 	return nil
-}
-
-
-func totalTokens(e jsonl.UsageEntry) int {
-	return e.InputTokens + e.OutputTokens + e.CacheCreationInputTokens + e.CacheReadInputTokens
 }

--- a/internal/jsonl/parser.go
+++ b/internal/jsonl/parser.go
@@ -21,6 +21,11 @@ type UsageEntry struct {
 	CacheReadInputTokens     int
 }
 
+// TotalTokens returns the sum of all token types in this entry.
+func (e UsageEntry) TotalTokens() int {
+	return e.InputTokens + e.OutputTokens + e.CacheCreationInputTokens + e.CacheReadInputTokens
+}
+
 type rawEntry struct {
 	Type      string    `json:"type"`
 	UUID      string    `json:"uuid"`

--- a/internal/report/monthly.go
+++ b/internal/report/monthly.go
@@ -40,7 +40,7 @@ func ComputeMonthly(entries []jsonl.UsageEntry, now time.Time) *MonthlyData {
 		if ts.Before(prevStart) || !ts.Before(prevEnd) {
 			continue
 		}
-		t := TotalTokens(e)
+		t := e.TotalTokens()
 		total += t
 		byModel[ClassifyModel(e.Model)] += t
 	}
@@ -65,9 +65,4 @@ func ClassifyModel(model string) string {
 	default:
 		return "Other"
 	}
-}
-
-// TotalTokens returns the sum of all token types in a UsageEntry.
-func TotalTokens(e jsonl.UsageEntry) int {
-	return e.InputTokens + e.OutputTokens + e.CacheCreationInputTokens + e.CacheReadInputTokens
 }

--- a/internal/service/usage.go
+++ b/internal/service/usage.go
@@ -127,7 +127,7 @@ func Compute(cfg Config) (*UsageResult, error) {
 		if e.Timestamp.Before(weekStart) {
 			continue
 		}
-		t := totalTokens(e)
+		t := e.TotalTokens()
 		result.WeeklyTokens += t
 		if isSonnet(e.Model) {
 			result.WeeklySonnetTokens += t
@@ -163,10 +163,6 @@ func lastWeeklyReset(day time.Weekday, hour int) time.Time {
 
 func nextWeeklyReset(day time.Weekday, hour int) time.Time {
 	return lastWeeklyReset(day, hour).AddDate(0, 0, 7)
-}
-
-func totalTokens(e jsonl.UsageEntry) int {
-	return e.InputTokens + e.OutputTokens + e.CacheCreationInputTokens + e.CacheReadInputTokens
 }
 
 func isSonnet(model string) bool {


### PR DESCRIPTION
## 概要

`UsageEntry` の input / output / cache_creation / cache_read を合算する関数が以下 3 箇所で重複していたため、`UsageEntry` のメソッド `TotalTokens()` として `internal/jsonl/parser.go` に集約した。

| 元の場所 | 元の名前 | 可視性 |
| --- | --- | --- |
| `internal/blocks/blocks.go` | `totalTokens` | private |
| `internal/service/usage.go` | `totalTokens` | private |
| `internal/report/monthly.go` | `TotalTokens` | public |

## 変更内容

- `internal/jsonl/parser.go` に `func (e UsageEntry) TotalTokens() int` を追加
- `internal/blocks/blocks.go`, `internal/service/usage.go`, `internal/report/monthly.go` の重複定義を削除
- 呼び出し側 (`cmd/report/main.go` 含む) を `e.TotalTokens()` に置換

## 振る舞い

- 計算ロジックは同一 (`Input + Output + CacheCreationInputTokens + CacheReadInputTokens`) のため、出力に変化はない

## Test plan

- [x] `go build ./...` がパス
- [x] `go test ./...` がパス（既存テストすべて green）
- [x] `go vet ./...` がパス
- [ ] CI (`test.yml`) がグリーン

Closes #53