### PR TITLE
refactor: トークン整形ヘルパ formatM/fmtTok を internal/numfmt に集約 (#62)

### DIFF
--- a/cmd/current/main.go
+++ b/cmd/current/main.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/rengotaku/claude-usage-tracker/internal/cache"
 	"github.com/rengotaku/claude-usage-tracker/internal/config"
+	"github.com/rengotaku/claude-usage-tracker/internal/numfmt"
 	"github.com/rengotaku/claude-usage-tracker/internal/service"
 )
 
@@ -142,7 +143,7 @@ func main() {
 	fmt.Printf("Current session   %s\n", sessionLine(result))
 	b := result.SessionBreakdown
 	fmt.Printf("  input %-8s  output %-8s  cache_creation %-8s  cache_read %s\n",
-		formatM(b.Input), formatM(b.Output), formatM(b.CacheCreation), formatM(b.CacheRead))
+		numfmt.Tokens(b.Input), numfmt.Tokens(b.Output), numfmt.Tokens(b.CacheCreation), numfmt.Tokens(b.CacheRead))
 	fmt.Printf("Weekly (All)      %s\n", weeklyLine(result.WeeklyTokens, result.WeeklyLimit, result.WeeklyRatio, resetsAt))
 	fmt.Printf("Weekly (Sonnet)   %s\n", weeklyLine(result.WeeklySonnetTokens, result.WeeklySonnetLimit, result.WeeklySonnetRatio, resetsAt))
 
@@ -155,7 +156,7 @@ func main() {
 		sort.Strings(models)
 		for _, m := range models {
 			bd := result.WeeklyModelBreakdown[m]
-			fmt.Printf("  %-38s %s\n", m, formatM(bd.Total()))
+			fmt.Printf("  %-38s %s\n", m, numfmt.Tokens(bd.Total()))
 		}
 	}
 }
@@ -167,16 +168,16 @@ func sessionLine(r *service.UsageResult) string {
 	}
 	if r.SessionLimit > 0 {
 		pct := r.SessionRatio * 100
-		return fmt.Sprintf("%.0f%% used (%s / %s%s)", pct, formatM(r.SessionTokens), formatM(r.SessionLimit), endsAt)
+		return fmt.Sprintf("%.0f%% used (%s / %s%s)", pct, numfmt.Tokens(r.SessionTokens), numfmt.Tokens(r.SessionLimit), endsAt)
 	}
-	return fmt.Sprintf("%s used%s", formatM(r.SessionTokens), endsAt)
+	return fmt.Sprintf("%s used%s", numfmt.Tokens(r.SessionTokens), endsAt)
 }
 
 func weeklyLine(tokens, limit int, ratio float64, resetsAt string) string {
 	if limit > 0 {
-		return fmt.Sprintf("%.0f%% used (%s / %s, resets %s (Asia/Tokyo))", ratio*100, formatM(tokens), formatM(limit), resetsAt)
+		return fmt.Sprintf("%.0f%% used (%s / %s, resets %s (Asia/Tokyo))", ratio*100, numfmt.Tokens(tokens), numfmt.Tokens(limit), resetsAt)
 	}
-	return fmt.Sprintf("%s used (resets %s (Asia/Tokyo))", formatM(tokens), resetsAt)
+	return fmt.Sprintf("%s used (resets %s (Asia/Tokyo))", numfmt.Tokens(tokens), resetsAt)
 }
 
 func logPlanDetection(logger *slog.Logger, cfg service.Config) {
@@ -187,12 +188,4 @@ func logPlanDetection(logger *slog.Logger, cfg service.Config) {
 		"tier", cfg.DetectedTier,
 		"session_limit", cfg.SessionLimit,
 	)
-}
-
-func formatM(n int) string {
-	m := float64(n) / 1_000_000
-	if m < 1 {
-		return fmt.Sprintf("%.0fk", float64(n)/1_000)
-	}
-	return fmt.Sprintf("%.0fM", m)
 }

--- a/internal/numfmt/numfmt.go
+++ b/internal/numfmt/numfmt.go
@@ -1,0 +1,19 @@
+// Package numfmt provides numeric formatting helpers shared across CLI/report output.
+package numfmt
+
+import "fmt"
+
+// Tokens formats an integer token count using k/M suffixes.
+//
+//	n >= 1_000_000 -> "<x>M"
+//	n >= 1_000     -> "<x>k"
+//	otherwise      -> raw integer
+func Tokens(n int) string {
+	if n >= 1_000_000 {
+		return fmt.Sprintf("%.0fM", float64(n)/1_000_000)
+	}
+	if n >= 1_000 {
+		return fmt.Sprintf("%.0fk", float64(n)/1_000)
+	}
+	return fmt.Sprintf("%d", n)
+}

--- a/internal/numfmt/numfmt_test.go
+++ b/internal/numfmt/numfmt_test.go
@@ -1,0 +1,27 @@
+package numfmt
+
+import "testing"
+
+func TestTokens(t *testing.T) {
+	cases := []struct {
+		name string
+		in   int
+		want string
+	}{
+		{"zero", 0, "0"},
+		{"under_1k", 999, "999"},
+		{"exactly_1k", 1_000, "1k"},
+		{"between_1k_and_1M", 12_345, "12k"},
+		{"just_under_1M", 999_999, "1000k"},
+		{"exactly_1M", 1_000_000, "1M"},
+		{"large_M", 23_500_000, "24M"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := Tokens(tc.in)
+			if got != tc.want {
+				t.Errorf("Tokens(%d) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/report/builder.go
+++ b/internal/report/builder.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/rengotaku/claude-usage-tracker/internal/blocks"
+	"github.com/rengotaku/claude-usage-tracker/internal/numfmt"
 	"github.com/rengotaku/claude-usage-tracker/internal/service"
 )
 
@@ -43,9 +44,9 @@ func buildSession(u *service.UsageResult) string {
 	var sb strings.Builder
 	sb.WriteString("### セッション (現在の5h ブロック)\n\n")
 
-	usageLine := fmtTok(u.SessionTokens)
+	usageLine := numfmt.Tokens(u.SessionTokens)
 	if u.SessionLimit > 0 {
-		usageLine = fmt.Sprintf("%s (%s / %s)", fmtPct(u.SessionRatio), fmtTok(u.SessionTokens), fmtTok(u.SessionLimit))
+		usageLine = fmt.Sprintf("%s (%s / %s)", fmtPct(u.SessionRatio), numfmt.Tokens(u.SessionTokens), numfmt.Tokens(u.SessionLimit))
 	}
 	if u.SessionEndsAt != nil {
 		usageLine += fmt.Sprintf(" — ブロック終了: %s", u.SessionEndsAt.In(jst).Format("2006-01-02T15:04:05+09:00"))
@@ -56,7 +57,7 @@ func buildSession(u *service.UsageResult) string {
 	sb.WriteString("**トークン内訳**\n\n")
 	sb.WriteString("| input | output | cache_creation | cache_read |\n")
 	sb.WriteString("|-------|--------|----------------|------------|\n")
-	fmt.Fprintf(&sb, "| %s | %s | %s | %s |\n\n", fmtTok(b.Input), fmtTok(b.Output), fmtTok(b.CacheCreation), fmtTok(b.CacheRead))
+	fmt.Fprintf(&sb, "| %s | %s | %s | %s |\n\n", numfmt.Tokens(b.Input), numfmt.Tokens(b.Output), numfmt.Tokens(b.CacheCreation), numfmt.Tokens(b.CacheRead))
 	return sb.String()
 }
 
@@ -64,13 +65,13 @@ func buildWeekly(u *service.UsageResult, modelBreakdown map[string]int) string {
 	var sb strings.Builder
 	sb.WriteString("### 週次使用量\n\n")
 
-	allLine := fmtTok(u.WeeklyTokens)
+	allLine := numfmt.Tokens(u.WeeklyTokens)
 	if u.WeeklyLimit > 0 {
-		allLine = fmt.Sprintf("%s (%s / %s)", fmtPct(u.WeeklyRatio), fmtTok(u.WeeklyTokens), fmtTok(u.WeeklyLimit))
+		allLine = fmt.Sprintf("%s (%s / %s)", fmtPct(u.WeeklyRatio), numfmt.Tokens(u.WeeklyTokens), numfmt.Tokens(u.WeeklyLimit))
 	}
-	sonnetLine := fmtTok(u.WeeklySonnetTokens)
+	sonnetLine := numfmt.Tokens(u.WeeklySonnetTokens)
 	if u.WeeklySonnetLimit > 0 {
-		sonnetLine = fmt.Sprintf("%s (%s / %s)", fmtPct(u.WeeklySonnetRatio), fmtTok(u.WeeklySonnetTokens), fmtTok(u.WeeklySonnetLimit))
+		sonnetLine = fmt.Sprintf("%s (%s / %s)", fmtPct(u.WeeklySonnetRatio), numfmt.Tokens(u.WeeklySonnetTokens), numfmt.Tokens(u.WeeklySonnetLimit))
 	}
 	resetsAt := u.WeeklyResetsAt.In(jst).Format("2006-01-02T15:04:05+09:00")
 
@@ -90,7 +91,7 @@ func buildWeekly(u *service.UsageResult, modelBreakdown map[string]int) string {
 			return modelBreakdown[models[i]] > modelBreakdown[models[j]]
 		})
 		for _, m := range models {
-			fmt.Fprintf(&sb, "| %s | %s |\n", m, fmtTok(modelBreakdown[m]))
+			fmt.Fprintf(&sb, "| %s | %s |\n", m, numfmt.Tokens(modelBreakdown[m]))
 		}
 		sb.WriteString("\n")
 	}
@@ -113,7 +114,7 @@ func buildBlocks(bs []blocks.Block) string {
 		fmt.Fprintf(&sb, "| %s | %s | %s |\n",
 			b.StartTime.In(jst).Format("2006-01-02 15:04"),
 			end,
-			fmtTok(b.TotalTokens),
+			numfmt.Tokens(b.TotalTokens),
 		)
 	}
 	sb.WriteString("\n")
@@ -123,7 +124,7 @@ func buildBlocks(bs []blocks.Block) string {
 func buildMonthly(m *MonthlyData) string {
 	var sb strings.Builder
 	fmt.Fprintf(&sb, "### 前月総括 (%s)\n\n", m.Label)
-	fmt.Fprintf(&sb, "**月間トータル**: %s\n\n", fmtTok(m.TotalTokens))
+	fmt.Fprintf(&sb, "**月間トータル**: %s\n\n", numfmt.Tokens(m.TotalTokens))
 	sb.WriteString("**モデル別内訳**\n\n")
 	sb.WriteString("| モデル | トークン |\n")
 	sb.WriteString("|--------|----------|\n")
@@ -138,21 +139,11 @@ func buildMonthly(m *MonthlyData) string {
 			return m.ByModel[models[i]] > m.ByModel[models[j]]
 		})
 		for _, k := range models {
-			fmt.Fprintf(&sb, "| %s | %s |\n", k, fmtTok(m.ByModel[k]))
+			fmt.Fprintf(&sb, "| %s | %s |\n", k, numfmt.Tokens(m.ByModel[k]))
 		}
 	}
 	sb.WriteString("\n")
 	return sb.String()
-}
-
-func fmtTok(n int) string {
-	if n >= 1_000_000 {
-		return fmt.Sprintf("%.0fM", float64(n)/1_000_000)
-	}
-	if n >= 1_000 {
-		return fmt.Sprintf("%.0fk", float64(n)/1_000)
-	}
-	return fmt.Sprintf("%d", n)
 }
 
 func fmtPct(ratio float64) string {


### PR DESCRIPTION
## 概要

`cmd/current/main.go` の `formatM` と `internal/report/builder.go` の `fmtTok` に存在していた、トークン数を `M` / `k` 単位に整形するヘルパ関数の重複を `internal/numfmt` パッケージに集約した。

closes #62

## 変更点

- `internal/numfmt/numfmt.go`: 新規作成。`Tokens(n int) string` を実装
  - `n >= 1_000_000` -> `"<x>M"`
  - `n >= 1_000` -> `"<x>k"`
  - それ以外 -> 生数
- `internal/numfmt/numfmt_test.go`: 境界値（0, 999, 1_000, 999_999, 1_000_000, 大きな値）を網羅
- `cmd/current/main.go`: 旧 `formatM` を削除し全呼び出しを `numfmt.Tokens` に置換
- `internal/report/builder.go`: 旧 `fmtTok` を削除し全呼び出しを `numfmt.Tokens` に置換

## 設計判断

- `fmtTok` のロジック（1k 未満は生数）を採用。`cmd/current` の出力で 0 トークン値が `"0k"` → `"0"` に変わるが、より自然な表示になる軽微な改善。
- パッケージは数値整形専用の小さなユーティリティのため `internal/numfmt` として独立配置。今後の `Pct` などの追加にも備えられる。

## 影響範囲

- 変更があるのは CLI 出力（`cmd/current`）と週次レポート（`internal/report`）のみ。
- JSON API レスポンス・DB スキーマ・キャッシュフォーマットへの影響なし。

## テスト

- `make build`: 成功
- `make test`: 全パッケージ pass（`internal/numfmt` の新規テスト含む）
- `go vet ./...`: クリーン
