### PR TITLE
refactor: blocks.BlockDuration を公開し 5*time.Hour 重複を解消 (#65)

### DIFF
--- a/internal/blocks/blocks.go
+++ b/internal/blocks/blocks.go
@@ -7,7 +7,8 @@ import (
 	"github.com/rengotaku/claude-usage-tracker/internal/jsonl"
 )
 
-const blockDuration = 5 * time.Hour
+// BlockDuration is the length of a single Claude session billing block.
+const BlockDuration = 5 * time.Hour
 
 // TokenBreakdown holds per-type token counts for a block.
 type TokenBreakdown struct {
@@ -53,7 +54,7 @@ func Build(entries []jsonl.UsageEntry) []Block {
 			start := e.Timestamp.UTC().Truncate(time.Second)
 			b := Block{
 				StartTime:      start,
-				EndTime:        start.Add(blockDuration),
+				EndTime:        start.Add(BlockDuration),
 				ModelBreakdown: make(map[string]TokenBreakdown),
 			}
 			blocks = append(blocks, b)

--- a/internal/blocks/blocks_test.go
+++ b/internal/blocks/blocks_test.go
@@ -54,8 +54,8 @@ func TestBuild_SingleEntry(t *testing.T) {
 	if !b.StartTime.Equal(want) {
 		t.Errorf("StartTime: want %v, got %v", want, b.StartTime)
 	}
-	if !b.EndTime.Equal(want.Add(5 * time.Hour)) {
-		t.Errorf("EndTime: want %v, got %v", want.Add(5*time.Hour), b.EndTime)
+	if !b.EndTime.Equal(want.Add(blocks.BlockDuration)) {
+		t.Errorf("EndTime: want %v, got %v", want.Add(blocks.BlockDuration), b.EndTime)
 	}
 	if b.TotalTokens != 38 {
 		t.Errorf("TotalTokens: want 38, got %d", b.TotalTokens)

--- a/internal/repository/snapshot_test.go
+++ b/internal/repository/snapshot_test.go
@@ -24,7 +24,7 @@ func TestSaveAndLatest(t *testing.T) {
 	ctx := context.Background()
 
 	now := time.Now().UTC().Truncate(time.Second)
-	end := now.Add(5 * time.Hour)
+	end := now.Add(blocks.BlockDuration)
 	s := repository.Snapshot{
 		TakenAt:        now,
 		BlockStartedAt: now,

--- a/internal/server/handlers_test.go
+++ b/internal/server/handlers_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/rengotaku/claude-usage-tracker/internal/blocks"
 	"github.com/rengotaku/claude-usage-tracker/internal/repository"
 	"github.com/rengotaku/claude-usage-tracker/internal/server"
 )
@@ -44,7 +45,7 @@ func decode[T any](t *testing.T, rec *httptest.ResponseRecorder) T {
 func TestSnapshotsEndpoint(t *testing.T) {
 	r := newTestRepo(t)
 	base := time.Date(2026, 4, 14, 10, 0, 0, 0, time.UTC)
-	end := base.Add(5 * time.Hour)
+	end := base.Add(blocks.BlockDuration)
 	seedSnapshots(t, r,
 		repository.Snapshot{TakenAt: base, BlockStartedAt: base, BlockEndedAt: &end, TokensUsed: 1000, UsageRatio: 0.02, WeeklyTokens: 1000},
 		repository.Snapshot{TakenAt: base.Add(time.Hour), BlockStartedAt: base, BlockEndedAt: &end, TokensUsed: 5000, UsageRatio: 0.10, WeeklyTokens: 5000},
@@ -88,9 +89,9 @@ func TestBlocksEndpointAggregation(t *testing.T) {
 	r := newTestRepo(t)
 	// Two snapshots in block A (tokens should be MAX), one snapshot in block B.
 	blockAStart := time.Date(2026, 4, 14, 10, 0, 0, 0, time.UTC)
-	blockAEnd := blockAStart.Add(5 * time.Hour)
+	blockAEnd := blockAStart.Add(blocks.BlockDuration)
 	blockBStart := blockAStart.Add(6 * time.Hour)
-	blockBEnd := blockBStart.Add(5 * time.Hour)
+	blockBEnd := blockBStart.Add(blocks.BlockDuration)
 	seedSnapshots(t, r,
 		repository.Snapshot{TakenAt: blockAStart, BlockStartedAt: blockAStart, BlockEndedAt: &blockAEnd, TokensUsed: 2000, UsageRatio: 0.04, WeeklyTokens: 2000},
 		repository.Snapshot{TakenAt: blockAStart.Add(time.Hour), BlockStartedAt: blockAStart, BlockEndedAt: &blockAEnd, TokensUsed: 8000, UsageRatio: 0.16, WeeklyTokens: 8000},
@@ -143,12 +144,12 @@ func TestDailyEndpoint(t *testing.T) {
 	r := newTestRepo(t)
 	// Day 1 (UTC 10:00 = JST 19:00 same day 2026-04-14): two blocks
 	d1a := time.Date(2026, 4, 14, 1, 0, 0, 0, time.UTC) // JST 10:00
-	d1aEnd := d1a.Add(5 * time.Hour)
+	d1aEnd := d1a.Add(blocks.BlockDuration)
 	d1b := time.Date(2026, 4, 14, 8, 0, 0, 0, time.UTC) // JST 17:00
-	d1bEnd := d1b.Add(5 * time.Hour)
+	d1bEnd := d1b.Add(blocks.BlockDuration)
 	// Day 2 (JST 2026-04-15)
 	d2 := time.Date(2026, 4, 15, 1, 0, 0, 0, time.UTC) // JST 10:00
-	d2End := d2.Add(5 * time.Hour)
+	d2End := d2.Add(blocks.BlockDuration)
 
 	seedSnapshots(t, r,
 		repository.Snapshot{TakenAt: d1a, BlockStartedAt: d1a, BlockEndedAt: &d1aEnd, TokensUsed: 5000, UsageRatio: 0.1},
@@ -189,10 +190,10 @@ func TestSummaryEndpoint(t *testing.T) {
 	now := time.Now().UTC()
 	// current week: one block 10000 tokens
 	cur := now.Add(-24 * time.Hour)
-	curEnd := cur.Add(5 * time.Hour)
+	curEnd := cur.Add(blocks.BlockDuration)
 	// previous week: one block 5000 tokens
 	prev := now.Add(-8 * 24 * time.Hour)
-	prevEnd := prev.Add(5 * time.Hour)
+	prevEnd := prev.Add(blocks.BlockDuration)
 
 	seedSnapshots(t, r,
 		repository.Snapshot{TakenAt: cur, BlockStartedAt: cur, BlockEndedAt: &curEnd, TokensUsed: 10000, UsageRatio: 0.2, WeeklyTokens: 10000, WeeklySonnetTokens: 4000},
@@ -235,7 +236,7 @@ func TestSummaryEndpoint(t *testing.T) {
 func TestBlocksFiltersPlaceholderSnapshots(t *testing.T) {
 	r := newTestRepo(t)
 	realStart := time.Date(2026, 4, 14, 10, 0, 0, 0, time.UTC)
-	realEnd := realStart.Add(5 * time.Hour)
+	realEnd := realStart.Add(blocks.BlockDuration)
 	// Placeholder (no active block): BlockEndedAt = nil, tokens = 0.
 	placeholder := time.Date(2026, 4, 14, 16, 30, 0, 0, time.UTC)
 	seedSnapshots(t, r,


### PR DESCRIPTION
## Summary

- `internal/blocks/blocks.go` で未公開だった `blockDuration` を **公開定数 `BlockDuration`** にリネーム
- テストコードに **11 箇所** 分散していた `5 * time.Hour` リテラルを `blocks.BlockDuration` に統一
- ブロック長の SSOT を確立し、将来の値変更時の修正漏れを防ぐ
- プロダクション挙動・公開 API は不変（同パッケージ内の利用のため）

Closes #65

## 変更ファイル

| ファイル | 変更内容 |
|---|---|
| `internal/blocks/blocks.go` | `blockDuration` → `BlockDuration` (公開) + コメント追加 |
| `internal/blocks/blocks_test.go` | 1 箇所 |
| `internal/repository/snapshot_test.go` | 1 箇所 |
| `internal/server/handlers_test.go` | 9 箇所 + `blocks` import 追加 |

## Test plan

- [x] `make build` がパスする
- [x] `make test` で全パッケージのテストがパスする
- [x] `go vet ./...` がエラー無し
- [x] 残る `5 * time.Hour` リテラルは `blocks.go` の定数定義 1 箇所のみ
- [ ] CI (test workflow) がパスする