### PR TITLE
refactor: builder.go のモデル別テーブル sort+iterate を writeModelRows に共通化 (#68)

### DIFF
--- a/internal/report/builder.go
+++ b/internal/report/builder.go
@@ -82,16 +82,7 @@ func buildWeekly(u *service.UsageResult, modelBreakdown map[string]int) string {
 		sb.WriteString("**週次モデル別内訳**\n\n")
 		sb.WriteString("| モデル | トークン |\n")
 		sb.WriteString("|--------|----------|\n")
-		models := make([]string, 0, len(modelBreakdown))
-		for m := range modelBreakdown {
-			models = append(models, m)
-		}
-		sort.Slice(models, func(i, j int) bool {
-			return modelBreakdown[models[i]] > modelBreakdown[models[j]]
-		})
-		for _, m := range models {
-			fmt.Fprintf(&sb, "| %s | %s |\n", m, fmtTok(modelBreakdown[m]))
-		}
+		writeModelRows(&sb, modelBreakdown)
 		sb.WriteString("\n")
 	}
 	return sb.String()
@@ -130,19 +121,26 @@ func buildMonthly(m *MonthlyData) string {
 	if len(m.ByModel) == 0 {
 		sb.WriteString("| (データなし) | — |\n")
 	} else {
-		models := make([]string, 0, len(m.ByModel))
-		for k := range m.ByModel {
-			models = append(models, k)
-		}
-		sort.Slice(models, func(i, j int) bool {
-			return m.ByModel[models[i]] > m.ByModel[models[j]]
-		})
-		for _, k := range models {
-			fmt.Fprintf(&sb, "| %s | %s |\n", k, fmtTok(m.ByModel[k]))
-		}
+		writeModelRows(&sb, m.ByModel)
 	}
 	sb.WriteString("\n")
 	return sb.String()
+}
+
+// writeModelRows writes one Markdown table row per model into sb,
+// sorted by token count in descending order. Caller is responsible for
+// the table header and any empty-state row.
+func writeModelRows(sb *strings.Builder, byModel map[string]int) {
+	models := make([]string, 0, len(byModel))
+	for m := range byModel {
+		models = append(models, m)
+	}
+	sort.Slice(models, func(i, j int) bool {
+		return byModel[models[i]] > byModel[models[j]]
+	})
+	for _, m := range models {
+		fmt.Fprintf(sb, "| %s | %s |\n", m, fmtTok(byModel[m]))
+	}
 }
 
 func fmtTok(n int) string {


### PR DESCRIPTION
## Summary

- `internal/report/builder.go` の `buildWeekly` と `buildMonthly` で完全同形だった「`map[string]int` をトークン降順ソートして `| model | fmtTok(n) |` 行を書き出す」10行ブロックを、共通ヘルパ `writeModelRows(*strings.Builder, map[string]int)` に抽出。
- 各呼び出し側の空マップ時の表示差分（weekly: テーブル自体を出さない / monthly: `(データなし)` 行を出す）はそのまま維持。
- 出力は完全に同一で、リグレッションは既存の `TestBuild_WeeklySection` / `TestBuild_MonthlySummary` が検出する想定。

Closes #68

## Test plan

- [x] `make build` が成功すること
- [x] `make test` が成功すること（既存 `internal/report` のテストはすべて pass）
- [ ] CI (test.yml) がグリーンであること