### PR TITLE
refactor: builder.go のモデル別テーブル sort+iterate を writeModelRows に集約 (#68)

### DIFF
--- a/internal/report/builder.go
+++ b/internal/report/builder.go
@@ -83,19 +83,24 @@ func buildWeekly(u *service.UsageResult, modelBreakdown map[string]int) string {
 		sb.WriteString("**週次モデル別内訳**\n\n")
 		sb.WriteString("| モデル | トークン |\n")
 		sb.WriteString("|--------|----------|\n")
-		models := make([]string, 0, len(modelBreakdown))
-		for m := range modelBreakdown {
-			models = append(models, m)
-		}
-		sort.Slice(models, func(i, j int) bool {
-			return modelBreakdown[models[i]] > modelBreakdown[models[j]]
-		})
-		for _, m := range models {
-			fmt.Fprintf(&sb, "| %s | %s |\n", m, numfmt.Tokens(modelBreakdown[m]))
-		}
+		writeModelRows(&sb, modelBreakdown)
 		sb.WriteString("\n")
 	}
 	return sb.String()
+}
+
+// writeModelRows writes one Markdown table row per model, sorted by token count desc.
+func writeModelRows(sb *strings.Builder, byModel map[string]int) {
+	models := make([]string, 0, len(byModel))
+	for m := range byModel {
+		models = append(models, m)
+	}
+	sort.Slice(models, func(i, j int) bool {
+		return byModel[models[i]] > byModel[models[j]]
+	})
+	for _, m := range models {
+		fmt.Fprintf(sb, "| %s | %s |\n", m, numfmt.Tokens(byModel[m]))
+	}
 }
 
 func buildBlocks(bs []blocks.Block) string {
@@ -131,16 +136,7 @@ func buildMonthly(m *MonthlyData) string {
 	if len(m.ByModel) == 0 {
 		sb.WriteString("| (データなし) | — |\n")
 	} else {
-		models := make([]string, 0, len(m.ByModel))
-		for k := range m.ByModel {
-			models = append(models, k)
-		}
-		sort.Slice(models, func(i, j int) bool {
-			return m.ByModel[models[i]] > m.ByModel[models[j]]
-		})
-		for _, k := range models {
-			fmt.Fprintf(&sb, "| %s | %s |\n", k, numfmt.Tokens(m.ByModel[k]))
-		}
+		writeModelRows(&sb, m.ByModel)
 	}
 	sb.WriteString("\n")
 	return sb.String()


### PR DESCRIPTION
## Summary

- `internal/report/builder.go` の `buildWeekly` / `buildMonthly` で重複していた、`map[string]int` のトークン降順ソート→Markdown テーブル行書き出し (10行) を、未公開ヘルパ `writeModelRows` に集約。
- 出力フォーマットは完全に同一。空マップ時の表示差分 (weekly: テーブルごと省略 / monthly: \`(データなし)\` 行) は呼び出し側に残しています。

## Why

Issue #68 の通り、両ブロックは変数名以外完全に同形で DRY 違反。将来「ソートキー変更」「列追加」等で両方を直し漏れるリスクがありました。直近の PR #42 / #44 と同じ重複整理の流れに沿った最小修正です。

## Test plan

- [x] \`go build ./...\` パス
- [x] \`go test ./...\` パス（既存の \`TestBuild_WeeklySection\` / \`TestBuild_MonthlySummary\` がリグレッション検出に十分）
- [ ] CI (test.yml) がグリーン

Closes #68