### PR TITLE
refactor: jsonl parser の EOF 検出を errors.Is(err, io.EOF) に修正 (#71)

### DIFF
--- a/internal/jsonl/parser.go
+++ b/internal/jsonl/parser.go
@@ -3,6 +3,8 @@ package jsonl
 import (
 	"bufio"
 	"encoding/json"
+	"errors"
+	"io"
 	"io/fs"
 	"log"
 	"os"
@@ -99,7 +101,7 @@ func parseFile(path string, seen map[string]struct{}) ([]UsageEntry, error) {
 			}
 		}
 		if err != nil {
-			if err.Error() == "EOF" {
+			if errors.Is(err, io.EOF) {
 				break
 			}
 			return nil, err


### PR DESCRIPTION
Closes #71

## 概要

`internal/jsonl/parser.go` の `parseFile` で、`bufio.Reader.ReadBytes` が返すエラーを `err.Error() == \"EOF\"` という文字列比較で EOF 判定していたのを、`errors.Is(err, io.EOF)` に置き換えた。

```diff
-import (
-	\"bufio\"
-	\"encoding/json\"
-	\"io/fs\"
+import (
+	\"bufio\"
+	\"encoding/json\"
+	\"errors\"
+	\"io\"
+	\"io/fs\"
 ...
 		if err != nil {
-			if err.Error() == \"EOF\" {
+			if errors.Is(err, io.EOF) {
 				break
 			}
 			return nil, err
 		}
```

## 変更点

- `internal/jsonl/parser.go`
  - `errors`, `io` を import に追加
  - `parseFile` の EOF 判定を `errors.Is(err, io.EOF)` に置換

## 振る舞い

不変。`bufio.Reader.ReadBytes` は終端で `io.EOF` を返すため、これまで検出していたケースを引き続き検出する。加えてラップされた EOF にも対応する。

## 動作確認

- [x] \`go build ./...\` がパス
- [x] \`go vet ./...\` がパス
- [x] \`go test ./...\` がパス（`internal/jsonl` の既存テストが parseFile の EOF 経路を通る）
- [ ] CI (test.yml) がグリーン（PR 作成後に確認）