### PR TITLE
refactor: jsonl parser の EOF 検出を errors.Is(err, io.EOF) に変更

### DIFF
--- a/internal/jsonl/parser.go
+++ b/internal/jsonl/parser.go
@@ -3,6 +3,8 @@ package jsonl
 import (
 	"bufio"
 	"encoding/json"
+	"errors"
+	"io"
 	"io/fs"
 	"log"
 	"os"
@@ -99,7 +101,7 @@ func parseFile(path string, seen map[string]struct{}) ([]UsageEntry, error) {
 			}
 		}
 		if err != nil {
-			if err.Error() == "EOF" {
+			if errors.Is(err, io.EOF) {
 				break
 			}
 			return nil, err


### PR DESCRIPTION
## Summary

- `internal/jsonl/parser.go` の `parseFile` で `err.Error() == "EOF"` という文字列比較を行っていた箇所を、Go の慣用である `errors.Is(err, io.EOF)` に置き換える。
- ラップされた `io.EOF` にも追従できるようになり、将来のリーダー差し替え時の silent breakage を防げる。

Closes #71

## Changes

- `internal/jsonl/parser.go`
  - `errors`, `io` パッケージを import
  - `err.Error() == "EOF"` → `errors.Is(err, io.EOF)`

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...` （全パッケージ pass）
- [ ] CI (test.yml) がグリーン