### PR TITLE
refactor: jsonl parser の EOF 検出を errors.Is に修正 (#71)

### DIFF
--- a/internal/jsonl/parser.go
+++ b/internal/jsonl/parser.go
@@ -3,6 +3,8 @@ package jsonl
 import (
 	"bufio"
 	"encoding/json"
+	"errors"
+	"io"
 	"io/fs"
 	"log"
 	"os"
@@ -99,7 +101,7 @@ func parseFile(path string, seen map[string]struct{}) ([]UsageEntry, error) {
 			}
 		}
 		if err != nil {
-			if err.Error() == "EOF" {
+			if errors.Is(err, io.EOF) {
 				break
 			}
 			return nil, err


### PR DESCRIPTION
## 概要

Closes #71

`internal/jsonl/parser.go` の `parseFile` で、`bufio.Reader.ReadBytes` が返すエラーが EOF かどうかを文字列比較で判定していた箇所を `errors.Is(err, io.EOF)` に置き換える。

## 変更内容

- `err.Error() == "EOF"` → `errors.Is(err, io.EOF)`
- `errors` / `io` パッケージを import 追加

## 効果

- Go の慣用に沿った EOF 判定（センチネルエラー）。
- 将来 `fmt.Errorf("...: %w", io.EOF)` のようにラップされても検出できる。
- 振る舞い不変。`bufio.Reader.ReadBytes` は終端で `io.EOF` を返すため、現状検出していたケースを引き続き検出する。

## 検証

- [x] \`go build ./...\` パス
- [x] \`go vet ./...\` パス
- [x] \`go test ./...\` 全パッケージグリーン