### PR TITLE
refactor: ComputeMonthly の前月開始日計算を AddDate で簡略化

### DIFF
--- a/internal/report/monthly.go
+++ b/internal/report/monthly.go
@@ -23,13 +23,8 @@ func ComputeMonthly(entries []jsonl.UsageEntry, now time.Time) *MonthlyData {
 	}
 
 	firstOfMonth := time.Date(now.Year(), now.Month(), 1, 0, 0, 0, 0, time.UTC)
+	prevStart := firstOfMonth.AddDate(0, -1, 0)
 	prevEnd := firstOfMonth
-	var prevStart time.Time
-	if firstOfMonth.Month() == time.January {
-		prevStart = time.Date(firstOfMonth.Year()-1, time.December, 1, 0, 0, 0, 0, time.UTC)
-	} else {
-		prevStart = time.Date(firstOfMonth.Year(), firstOfMonth.Month()-1, 1, 0, 0, 0, 0, time.UTC)
-	}
 
 	label := fmt.Sprintf("%d-%02d", prevStart.Year(), prevStart.Month())
 	byModel := map[string]int{}


### PR DESCRIPTION
## Summary
- `ComputeMonthly` で前月の開始日を求める if/else 分岐を `firstOfMonth.AddDate(0, -1, 0)` 一行に置換
- January 特殊扱いを削除（`AddDate` が年跨ぎを正しく扱う）
- 振る舞い不変、既存テストでリグレッション検出可能

Closes #61

## Changes
- `internal/report/monthly.go`: `prevStart` の算出を `AddDate` に統一（5 行→1 行）

## Test plan
- [x] `go build ./...` 成功
- [x] `go test ./internal/report/...` 全件パス（`TestComputeMonthly_JanuaryPrevMonth` を含む）
- [x] `go test ./...` 全件パス
- [x] `go vet ./...` 警告なし
- [ ] CI (test.yml) グリーン