### PR TITLE
refactor: ハードコードされた JST RFC3339 フォーマットを time.RFC3339 に置換 (#76)

### DIFF
--- a/cmd/current/main.go
+++ b/cmd/current/main.go
@@ -108,7 +108,7 @@ func main() {
 		out.Session.Limit = result.SessionLimit
 		out.Session.Ratio = result.SessionRatio
 		if result.SessionEndsAt != nil {
-			out.Session.EndsAt = result.SessionEndsAt.In(jst).Format("2006-01-02T15:04:05+09:00")
+			out.Session.EndsAt = result.SessionEndsAt.In(jst).Format(time.RFC3339)
 		}
 		out.Weekly.TokensUsed = result.WeeklyTokens
 		out.Weekly.Limit = result.WeeklyLimit
@@ -116,7 +116,7 @@ func main() {
 		out.Weekly.SonnetTokens = result.WeeklySonnetTokens
 		out.Weekly.SonnetLimit = result.WeeklySonnetLimit
 		out.Weekly.SonnetRatio = result.WeeklySonnetRatio
-		out.Weekly.ResetsAt = result.WeeklyResetsAt.In(jst).Format("2006-01-02T15:04:05+09:00")
+		out.Weekly.ResetsAt = result.WeeklyResetsAt.In(jst).Format(time.RFC3339)
 		if len(result.WeeklyModelBreakdown) > 0 {
 			out.Weekly.ModelBreakdown = make(map[string]tokenBreakdownJSON, len(result.WeeklyModelBreakdown))
 			for model, bd := range result.WeeklyModelBreakdown {

--- a/internal/report/builder.go
+++ b/internal/report/builder.go
@@ -48,7 +48,7 @@ func buildSession(u *service.UsageResult) string {
 		usageLine = fmt.Sprintf("%s (%s / %s)", fmtPct(u.SessionRatio), fmtTok(u.SessionTokens), fmtTok(u.SessionLimit))
 	}
 	if u.SessionEndsAt != nil {
-		usageLine += fmt.Sprintf(" — ブロック終了: %s", u.SessionEndsAt.In(jst).Format("2006-01-02T15:04:05+09:00"))
+		usageLine += fmt.Sprintf(" — ブロック終了: %s", u.SessionEndsAt.In(jst).Format(time.RFC3339))
 	}
 	fmt.Fprintf(&sb, "- 使用率: %s\n\n", usageLine)
 
@@ -72,7 +72,7 @@ func buildWeekly(u *service.UsageResult, modelBreakdown map[string]int) string {
 	if u.WeeklySonnetLimit > 0 {
 		sonnetLine = fmt.Sprintf("%s (%s / %s)", fmtPct(u.WeeklySonnetRatio), fmtTok(u.WeeklySonnetTokens), fmtTok(u.WeeklySonnetLimit))
 	}
-	resetsAt := u.WeeklyResetsAt.In(jst).Format("2006-01-02T15:04:05+09:00")
+	resetsAt := u.WeeklyResetsAt.In(jst).Format(time.RFC3339)
 
 	fmt.Fprintf(&sb, "- All: %s\n", allLine)
 	fmt.Fprintf(&sb, "- Sonnet: %s\n", sonnetLine)


### PR DESCRIPTION
## Summary

- Closes #76
- `internal/report/builder.go` と `cmd/current/main.go` の 4 箇所でハードコードされていたフォーマット文字列 `"2006-01-02T15:04:05+09:00"` を `time.RFC3339` に置換
- `+09:00` リテラルは実オフセットを反映しないため `.In(jst)` 呼び忘れで表示が乖離する潜在バグ要因。`time.RFC3339` (`Z07:00`) は実オフセットを反映するため安全側に倒れる
- 既に `.In(jst)` で JST に変換済みなので出力結果は不変

## Changes

| ファイル | 変更内容 |
|---|---|
| `internal/report/builder.go` | `Format("2006-01-02T15:04:05+09:00")` → `Format(time.RFC3339)` × 2 |
| `cmd/current/main.go` | `Format("2006-01-02T15:04:05+09:00")` → `Format(time.RFC3339)` × 2 |

## Test plan

- [x] `go build ./...` がパス
- [x] `go vet ./...` がパス
- [x] `make test` (= `CGO_ENABLED=0 go test ./...`) がパス
- [ ] CI (`.github/workflows/test.yml`) がグリーン