### PR TITLE
refactor: snapshot migrate でエラー文字列マッチングを PRAGMA table_info に置換 (#77)

### DIFF
--- a/internal/repository/snapshot.go
+++ b/internal/repository/snapshot.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 	"time"
 
 	_ "modernc.org/sqlite"
@@ -91,23 +90,60 @@ func (r *SnapshotRepository) migrate(ctx context.Context) error {
 		return fmt.Errorf("create table: %w", err)
 	}
 
-	// Add columns to existing tables (idempotent).
-	for _, col := range []string{
-		"ALTER TABLE snapshots ADD COLUMN weekly_tokens         INTEGER NOT NULL DEFAULT 0",
-		"ALTER TABLE snapshots ADD COLUMN weekly_sonnet_tokens  INTEGER NOT NULL DEFAULT 0",
-		"ALTER TABLE snapshots ADD COLUMN input_tokens          INTEGER NOT NULL DEFAULT 0",
-		"ALTER TABLE snapshots ADD COLUMN output_tokens         INTEGER NOT NULL DEFAULT 0",
-		"ALTER TABLE snapshots ADD COLUMN cache_creation_tokens INTEGER NOT NULL DEFAULT 0",
-		"ALTER TABLE snapshots ADD COLUMN cache_read_tokens     INTEGER NOT NULL DEFAULT 0",
-		"ALTER TABLE snapshots ADD COLUMN model_breakdown       TEXT NOT NULL DEFAULT '{}'",
-	} {
-		if _, err := r.db.ExecContext(ctx, col); err != nil {
-			if !strings.Contains(err.Error(), "duplicate column name") {
-				return fmt.Errorf("alter table: %w", err)
-			}
+	existing, err := r.existingColumns(ctx, "snapshots")
+	if err != nil {
+		return fmt.Errorf("inspect schema: %w", err)
+	}
+
+	// Add columns to existing tables created by older versions.
+	addColumns := []struct{ name, ddl string }{
+		{"weekly_tokens", "INTEGER NOT NULL DEFAULT 0"},
+		{"weekly_sonnet_tokens", "INTEGER NOT NULL DEFAULT 0"},
+		{"input_tokens", "INTEGER NOT NULL DEFAULT 0"},
+		{"output_tokens", "INTEGER NOT NULL DEFAULT 0"},
+		{"cache_creation_tokens", "INTEGER NOT NULL DEFAULT 0"},
+		{"cache_read_tokens", "INTEGER NOT NULL DEFAULT 0"},
+		{"model_breakdown", "TEXT NOT NULL DEFAULT '{}'"},
+	}
+	for _, c := range addColumns {
+		if _, ok := existing[c.name]; ok {
+			continue
+		}
+		stmt := fmt.Sprintf("ALTER TABLE snapshots ADD COLUMN %s %s", c.name, c.ddl)
+		if _, err := r.db.ExecContext(ctx, stmt); err != nil {
+			return fmt.Errorf("alter table add column %s: %w", c.name, err)
 		}
 	}
 	return nil
+}
+
+// existingColumns returns the set of column names currently present on table.
+func (r *SnapshotRepository) existingColumns(ctx context.Context, table string) (map[string]struct{}, error) {
+	rows, err := r.db.QueryContext(ctx, fmt.Sprintf("PRAGMA table_info(%s)", table))
+	if err != nil {
+		return nil, fmt.Errorf("pragma table_info: %w", err)
+	}
+	defer rows.Close()
+
+	cols := make(map[string]struct{})
+	for rows.Next() {
+		var (
+			cid     int
+			name    string
+			ctype   string
+			notNull int
+			dflt    sql.NullString
+			pk      int
+		)
+		if err := rows.Scan(&cid, &name, &ctype, &notNull, &dflt, &pk); err != nil {
+			return nil, fmt.Errorf("scan table_info: %w", err)
+		}
+		cols[name] = struct{}{}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return cols, nil
 }
 
 // Save inserts or replaces a Snapshot (upsert by taken_at).

--- a/internal/repository/snapshot_test.go
+++ b/internal/repository/snapshot_test.go
@@ -205,6 +205,38 @@ func TestSaveAndLatest_ModelBreakdown(t *testing.T) {
 	}
 }
 
+func TestMigrateIsIdempotent(t *testing.T) {
+	dir := t.TempDir()
+	dbPath := dir + "/snapshots.db"
+	ctx := context.Background()
+
+	r1, err := repository.NewSnapshotRepository(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("first open: %v", err)
+	}
+	now := time.Now().UTC().Truncate(time.Second)
+	if err := r1.Save(ctx, repository.Snapshot{
+		TakenAt: now, BlockStartedAt: now, TokensUsed: 7, UsageRatio: 0.07,
+	}); err != nil {
+		t.Fatalf("save: %v", err)
+	}
+	r1.Close()
+
+	// Reopening must re-run migration without error and preserve data.
+	r2, err := repository.NewSnapshotRepository(ctx, dbPath)
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	defer r2.Close()
+	got, err := r2.Latest(ctx)
+	if err != nil {
+		t.Fatalf("latest: %v", err)
+	}
+	if got == nil || got.TokensUsed != 7 {
+		t.Fatalf("expected snapshot tokens=7, got %+v", got)
+	}
+}
+
 func TestNullBlockEndedAt(t *testing.T) {
 	r := newTestRepo(t)
 	ctx := context.Background()


### PR DESCRIPTION
## Summary

- `internal/repository/snapshot.go` の `migrate()` で `strings.Contains(err.Error(), "duplicate column name")` を使った文字列マッチングを排除し、`PRAGMA table_info(snapshots)` で既存カラムを事前に列挙してフィルタする方式に変更
- ALTER TABLE 失敗時のエラーメッセージに対象カラム名を含めるよう改善 (`alter table add column %s: %w`)
- migrate の冪等性 (再オープンしてもデータが残ること) を確認する `TestMigrateIsIdempotent` を追加

Closes #77

## Why

エラーメッセージ文言に依存した判定はドライバや SQLite バージョンの変更で破綻する可能性があり、Go 慣用にも反する。`PRAGMA table_info` は SQLite 標準の介入手段であり、より堅牢で意図も明確。

## Test plan

- [x] `CGO_ENABLED=0 go build ./...`
- [x] `CGO_ENABLED=0 go vet ./...`
- [x] `CGO_ENABLED=0 go test ./...` 全パス
- [x] 新規 `TestMigrateIsIdempotent` が pass
- [ ] CI (test.yml) green