### PR TITLE
refactor: cmd/* の slog ロガー初期化を internal/logging に集約 (#79)

### DIFF
--- a/cmd/current/main.go
+++ b/cmd/current/main.go
@@ -12,6 +12,7 @@ import (
 	"github.com/rengotaku/claude-usage-tracker/internal/blocks"
 	"github.com/rengotaku/claude-usage-tracker/internal/cache"
 	"github.com/rengotaku/claude-usage-tracker/internal/config"
+	"github.com/rengotaku/claude-usage-tracker/internal/logging"
 	"github.com/rengotaku/claude-usage-tracker/internal/numfmt"
 	"github.com/rengotaku/claude-usage-tracker/internal/service"
 )
@@ -55,7 +56,7 @@ type jsonOutput struct {
 }
 
 func main() {
-	logger := slog.New(slog.NewJSONHandler(os.Stderr, nil))
+	logger := logging.NewDefault()
 
 	noCache := false
 	jsonFlag := false

--- a/cmd/report/main.go
+++ b/cmd/report/main.go
@@ -2,7 +2,6 @@ package main
 
 import (
 	"fmt"
-	"log/slog"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -11,6 +10,7 @@ import (
 	"github.com/rengotaku/claude-usage-tracker/internal/blocks"
 	"github.com/rengotaku/claude-usage-tracker/internal/config"
 	"github.com/rengotaku/claude-usage-tracker/internal/jsonl"
+	"github.com/rengotaku/claude-usage-tracker/internal/logging"
 	"github.com/rengotaku/claude-usage-tracker/internal/report"
 	"github.com/rengotaku/claude-usage-tracker/internal/service"
 )
@@ -20,7 +20,7 @@ var jst = time.FixedZone("JST", 9*60*60)
 const lastReportFile = ".local/share/claude-usage-tracker/last-usage-report.txt"
 
 func main() {
-	logger := slog.New(slog.NewJSONHandler(os.Stderr, nil))
+	logger := logging.NewDefault()
 
 	dryRun := false
 	force := false

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -2,19 +2,19 @@ package main
 
 import (
 	"context"
-	"log/slog"
 	"net/http"
 	"os"
 	"time"
 
 	"github.com/rengotaku/claude-usage-tracker/internal/config"
+	"github.com/rengotaku/claude-usage-tracker/internal/logging"
 	"github.com/rengotaku/claude-usage-tracker/internal/repository"
 	"github.com/rengotaku/claude-usage-tracker/internal/server"
 	"github.com/rengotaku/claude-usage-tracker/internal/service"
 )
 
 func main() {
-	logger := slog.New(slog.NewJSONHandler(os.Stderr, nil))
+	logger := logging.NewDefault()
 
 	appCfg, svcCfg, err := service.LoadAndValidateConfig(config.DefaultPath())
 	if err != nil {

--- a/cmd/snapshot/main.go
+++ b/cmd/snapshot/main.go
@@ -2,17 +2,17 @@ package main
 
 import (
 	"context"
-	"log/slog"
 	"os"
 	"time"
 
 	"github.com/rengotaku/claude-usage-tracker/internal/config"
+	"github.com/rengotaku/claude-usage-tracker/internal/logging"
 	"github.com/rengotaku/claude-usage-tracker/internal/repository"
 	"github.com/rengotaku/claude-usage-tracker/internal/service"
 )
 
 func main() {
-	logger := slog.New(slog.NewJSONHandler(os.Stderr, nil))
+	logger := logging.NewDefault()
 
 	appCfg, cfg, err := service.LoadAndValidateConfig(config.DefaultPath())
 	if err != nil {

--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -1,0 +1,12 @@
+package logging
+
+import (
+	"log/slog"
+	"os"
+)
+
+// NewDefault returns the standard slog.Logger used by all CLI binaries:
+// JSON output written to stderr.
+func NewDefault() *slog.Logger {
+	return slog.New(slog.NewJSONHandler(os.Stderr, nil))
+}


### PR DESCRIPTION
Closes #79

## 概要

各 `cmd/*/main.go` で同一だった以下の初期化を `internal/logging` パッケージに切り出し、4 箇所の重複を解消した。

```go
slog.New(slog.NewJSONHandler(os.Stderr, nil))
```

## 変更点

- 新規: `internal/logging/logging.go`
  - `logging.NewDefault() *slog.Logger` を提供。`os.Stderr` への JSON ハンドラを設定した既定のロガーを返す。
- 修正: `cmd/current/main.go`, `cmd/report/main.go`, `cmd/server/main.go`, `cmd/snapshot/main.go`
  - 重複した初期化を `logging.NewDefault()` 呼び出しに置換。
  - `cmd/current/main.go` は `*slog.Logger` を引数に取る `logPlanDetection` があるため `log/slog` import は維持。それ以外の3バイナリは `log/slog` import を削除。

## 振る舞い

不変。`logging.NewDefault()` は従来と同一の `slog.Logger` を返すため、ログ出力先 (stderr) と形式 (JSON) は変更されない。

## 動作確認

- `go build ./...` パス
- `go vet ./...` パス
- `go test ./...` パス（既存テストすべて緑）

## Test plan

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...`
- [ ] CI (test.yml) グリーン