### PR TITLE
refactor: server の SumWeeklyTokens / latestWeeklySonnet を maxSnapshotField に統合 (#82)

### DIFF
--- a/internal/server/aggregation.go
+++ b/internal/server/aggregation.go
@@ -82,14 +82,14 @@ func AggregateDaily(blocks []BlockAgg) []DailyAgg {
 	return result
 }
 
-// SumWeeklyTokens returns the latest weekly_tokens value observed in snaps
-// (the tracker stores a running weekly counter; the max/last value represents
-// the current weekly total for the range).
-func SumWeeklyTokens(snaps []repository.Snapshot) int {
+// maxSnapshotField returns the maximum value of an int field selected by getter
+// across snaps. Used to read running weekly counters that increase monotonically
+// within a week, so the maximum represents the current weekly total.
+func maxSnapshotField(snaps []repository.Snapshot, getter func(repository.Snapshot) int) int {
 	var max int
 	for _, s := range snaps {
-		if s.WeeklyTokens > max {
-			max = s.WeeklyTokens
+		if v := getter(s); v > max {
+			max = v
 		}
 	}
 	return max

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -206,7 +206,7 @@ func (h *Handler) Blocks(w http.ResponseWriter, r *http.Request) {
 		}
 		items = append(items, item)
 	}
-	weeklyTotal := SumWeeklyTokens(snaps)
+	weeklyTotal := maxSnapshotField(snaps, func(s repository.Snapshot) int { return s.WeeklyTokens })
 	weekly := weeklyDTO{TotalTokens: weeklyTotal, Limit: h.cfg.WeeklyLimit}
 	if h.cfg.WeeklyLimit > 0 {
 		weekly.Ratio = float64(weeklyTotal) / float64(h.cfg.WeeklyLimit)
@@ -321,7 +321,7 @@ func (h *Handler) Summary(w http.ResponseWriter, r *http.Request) {
 		Current:      periodSum{From: formatJST(curFrom), To: formatJST(now), Tokens: curTokens},
 		Previous:     periodSum{From: formatJST(prevFrom), To: formatJST(curFrom), Tokens: prevTokens},
 		DeltaRatio:   delta,
-		WeeklySonnet: latestWeeklySonnet(curSnaps),
+		WeeklySonnet: maxSnapshotField(curSnaps, func(s repository.Snapshot) int { return s.WeeklySonnetTokens }),
 	})
 }
 
@@ -331,14 +331,4 @@ func sumBlockTokens(aggs []BlockAgg) int {
 		sum += b.Tokens
 	}
 	return sum
-}
-
-func latestWeeklySonnet(snaps []repository.Snapshot) int {
-	var max int
-	for _, s := range snaps {
-		if s.WeeklySonnetTokens > max {
-			max = s.WeeklySonnetTokens
-		}
-	}
-	return max
 }


### PR DESCRIPTION
Closes #82

## 概要

\`internal/server\` に重複していた「snapshots の特定 int フィールドの最大値を返す」ヘルパ2つを、getter を引数に取る private ヘルパ \`maxSnapshotField\` 1 つに統合する。

## 変更点

- \`SumWeeklyTokens\` を削除（名前は Sum だが実装は max という誤命名のまま使われていた）
- \`latestWeeklySonnet\` を削除（\`SumWeeklyTokens\` と対象フィールド以外同一の重複）
- \`maxSnapshotField(snaps, getter)\` を \`internal/server/aggregation.go\` に追加
- 呼び出し側（\`Blocks\` / \`Summary\` ハンドラ）を新ヘルパに差し替え

## 振る舞い

- 不変。両関数とも純粋に max を返すループだったため、置換後も値・JSON 出力ともに同一。
- \`SumWeeklyTokens\` はパッケージ外参照無し（同パッケージ内 1 箇所のみ）のため API 影響なし。

## 確認

- \`go build ./...\` ✅
- \`go vet ./...\` ✅
- \`go test ./...\` ✅（既存ハンドラテスト経由で挙動不変を保証）

## Test plan

- [ ] CI (test.yml) がグリーン