### PR TITLE
refactor: service.Compute の lastWeeklyReset 重複呼び出しを集約 (#83)

### DIFF
--- a/internal/service/usage.go
+++ b/internal/service/usage.go
@@ -118,12 +118,14 @@ func Compute(cfg Config) (*UsageResult, error) {
 	bs := blocks.Build(entries)
 	active := blocks.ActiveBlock(bs)
 
+	weekStart := lastWeeklyReset(cfg.WeeklyResetDay, cfg.WeeklyResetHour)
+
 	result := &UsageResult{
 		SessionLimit:         cfg.SessionLimit,
 		WeeklyLimit:          cfg.WeeklyLimit,
 		WeeklySonnetLimit:    cfg.WeeklySonnetLimit,
-		WeeklyStartsAt:       lastWeeklyReset(cfg.WeeklyResetDay, cfg.WeeklyResetHour),
-		WeeklyResetsAt:       nextWeeklyReset(cfg.WeeklyResetDay, cfg.WeeklyResetHour),
+		WeeklyStartsAt:       weekStart,
+		WeeklyResetsAt:       weekStart.AddDate(0, 0, 7),
 		WeeklyModelBreakdown: make(map[string]blocks.TokenBreakdown),
 	}
 
@@ -138,7 +140,6 @@ func Compute(cfg Config) (*UsageResult, error) {
 		}
 	}
 
-	weekStart := lastWeeklyReset(cfg.WeeklyResetDay, cfg.WeeklyResetHour)
 	for _, e := range entries {
 		if e.Timestamp.Before(weekStart) {
 			continue
@@ -175,10 +176,6 @@ func lastWeeklyReset(day time.Weekday, hour int) time.Time {
 		reset = reset.AddDate(0, 0, -7)
 	}
 	return reset
-}
-
-func nextWeeklyReset(day time.Weekday, hour int) time.Time {
-	return lastWeeklyReset(day, hour).AddDate(0, 0, 7)
 }
 
 func isSonnet(model string) bool {


### PR DESCRIPTION
## 概要

closes #83

`internal/service/usage.go` の `Compute` で `lastWeeklyReset(cfg.WeeklyResetDay, cfg.WeeklyResetHour)` が 3 回呼ばれていたのを 1 回にまとめ、同じ `weekStart` を `WeeklyStartsAt` / `WeeklyResetsAt` / 週次集計のしきい値で共通利用するように整理した。

- `WeeklyResetsAt` は `weekStart.AddDate(0, 0, 7)` で導出
- 他で未使用だった `nextWeeklyReset` ヘルパは削除（YAGNI）

## 変更内容

- `internal/service/usage.go`
  - `weekStart := lastWeeklyReset(...)` を一度だけ計算
  - `WeeklyStartsAt = weekStart` / `WeeklyResetsAt = weekStart.AddDate(0, 0, 7)` に変更
  - 集計ループ前の重複した `weekStart := lastWeeklyReset(...)` を削除
  - `nextWeeklyReset` 関数を削除

## 振る舞い影響

なし。`nextWeeklyReset` は元々 `lastWeeklyReset(...).AddDate(0, 0, 7)` の薄いラッパだったため、計算結果は同一。`time.Now()` を 3 回読んでいたのを 1 回に減らすことで、リセット境界をマイクロ秒で跨ぐ理論上の不整合も解消される。

## 検証

- [x] `go build ./...`
- [x] `go vet ./...`
- [x] `go test ./...`
- [ ] CI (test.yml) グリーン