### PR TITLE
refactor: totalTokens の重複を jsonl.TotalTokens に統合

### DIFF
--- a/cmd/report/main.go
+++ b/cmd/report/main.go
@@ -119,7 +119,7 @@ func computeModelBreakdown(entries []jsonl.UsageEntry, weekStart time.Time) map[
 		if e.Timestamp.Before(weekStart) {
 			continue
 		}
-		byModel[report.ClassifyModel(e.Model)] += report.TotalTokens(e)
+		byModel[report.ClassifyModel(e.Model)] += jsonl.TotalTokens(e)
 	}
 	return byModel
 }

--- a/internal/blocks/blocks.go
+++ b/internal/blocks/blocks.go
@@ -59,7 +59,7 @@ func Build(entries []jsonl.UsageEntry) []Block {
 			blocks = append(blocks, b)
 			current = &blocks[len(blocks)-1]
 		}
-		current.TotalTokens += totalTokens(e)
+		current.TotalTokens += jsonl.TotalTokens(e)
 		current.Tokens.Input += e.InputTokens
 		current.Tokens.Output += e.OutputTokens
 		current.Tokens.CacheCreation += e.CacheCreationInputTokens
@@ -95,7 +95,3 @@ func ActiveBlock(blocks []Block) *Block {
 	return nil
 }
 
-
-func totalTokens(e jsonl.UsageEntry) int {
-	return e.InputTokens + e.OutputTokens + e.CacheCreationInputTokens + e.CacheReadInputTokens
-}

--- a/internal/jsonl/parser.go
+++ b/internal/jsonl/parser.go
@@ -37,6 +37,11 @@ type rawEntry struct {
 	} `json:"message"`
 }
 
+// TotalTokens returns the sum of all token types in a UsageEntry.
+func TotalTokens(e UsageEntry) int {
+	return e.InputTokens + e.OutputTokens + e.CacheCreationInputTokens + e.CacheReadInputTokens
+}
+
 // Parse walks dir and returns all unique UsageEntry records found in .jsonl files.
 func Parse(dir string) ([]UsageEntry, error) {
 	seen := make(map[string]struct{})

--- a/internal/report/monthly.go
+++ b/internal/report/monthly.go
@@ -40,7 +40,7 @@ func ComputeMonthly(entries []jsonl.UsageEntry, now time.Time) *MonthlyData {
 		if ts.Before(prevStart) || !ts.Before(prevEnd) {
 			continue
 		}
-		t := TotalTokens(e)
+		t := jsonl.TotalTokens(e)
 		total += t
 		byModel[ClassifyModel(e.Model)] += t
 	}
@@ -67,7 +67,3 @@ func ClassifyModel(model string) string {
 	}
 }
 
-// TotalTokens returns the sum of all token types in a UsageEntry.
-func TotalTokens(e jsonl.UsageEntry) int {
-	return e.InputTokens + e.OutputTokens + e.CacheCreationInputTokens + e.CacheReadInputTokens
-}

--- a/internal/service/usage.go
+++ b/internal/service/usage.go
@@ -127,7 +127,7 @@ func Compute(cfg Config) (*UsageResult, error) {
 		if e.Timestamp.Before(weekStart) {
 			continue
 		}
-		t := totalTokens(e)
+		t := jsonl.TotalTokens(e)
 		result.WeeklyTokens += t
 		if isSonnet(e.Model) {
 			result.WeeklySonnetTokens += t
@@ -165,9 +165,6 @@ func nextWeeklyReset(day time.Weekday, hour int) time.Time {
 	return lastWeeklyReset(day, hour).AddDate(0, 0, 7)
 }
 
-func totalTokens(e jsonl.UsageEntry) int {
-	return e.InputTokens + e.OutputTokens + e.CacheCreationInputTokens + e.CacheReadInputTokens
-}
 
 func isSonnet(model string) bool {
 	return strings.Contains(strings.ToLower(model), "sonnet")


### PR DESCRIPTION
## Summary

Closes #88

`totalTokens(e jsonl.UsageEntry) int` の同一実装が3ファイルに存在していたため、`UsageEntry` を定義する `jsonl` パッケージに統合した。

- `internal/jsonl/parser.go` に `TotalTokens(e UsageEntry) int` を追加
- `internal/blocks/blocks.go`: private `totalTokens` を削除し `jsonl.TotalTokens` を使用
- `internal/service/usage.go`: private `totalTokens` を削除し `jsonl.TotalTokens` を使用
- `internal/report/monthly.go`: exported `TotalTokens` を削除し `jsonl.TotalTokens` を使用
- `cmd/report/main.go`: `report.TotalTokens` 呼び出しを `jsonl.TotalTokens` に更新

## Test plan

- [x] `go build ./...` が通ること
- [x] `go test ./...` が全パスすること
- [ ] CI が green になること