### PR TITLE
refactor: TokenBreakdown JSON DTO の重複定義を blocks パッケージに統合

### DIFF
--- a/cmd/current/main.go
+++ b/cmd/current/main.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/rengotaku/claude-usage-tracker/internal/blocks"
 	"github.com/rengotaku/claude-usage-tracker/internal/cache"
 	"github.com/rengotaku/claude-usage-tracker/internal/config"
 	"github.com/rengotaku/claude-usage-tracker/internal/service"
@@ -15,20 +16,13 @@ import (
 
 var jst = time.FixedZone("JST", 9*60*60)
 
-type tokenBreakdownJSON struct {
-	Input         int `json:"input"`
-	Output        int `json:"output"`
-	CacheCreation int `json:"cache_creation"`
-	CacheRead     int `json:"cache_read"`
-}
-
 type jsonOutput struct {
 	Session struct {
-		TokensUsed int                `json:"tokens_used"`
-		Breakdown  tokenBreakdownJSON `json:"breakdown"`
-		Limit      int                `json:"limit,omitempty"`
-		Ratio      float64            `json:"ratio,omitempty"`
-		EndsAt     string             `json:"ends_at,omitempty"`
+		TokensUsed int                       `json:"tokens_used"`
+		Breakdown  blocks.TokenBreakdownJSON `json:"breakdown"`
+		Limit      int                       `json:"limit,omitempty"`
+		Ratio      float64                   `json:"ratio,omitempty"`
+		EndsAt     string                    `json:"ends_at,omitempty"`
 	} `json:"session"`
 	Weekly struct {
 		TokensUsed   int     `json:"tokens_used"`
@@ -94,12 +88,7 @@ func main() {
 	if jsonFlag {
 		out := jsonOutput{}
 		out.Session.TokensUsed = result.SessionTokens
-		out.Session.Breakdown = tokenBreakdownJSON{
-			Input:         result.SessionBreakdown.Input,
-			Output:        result.SessionBreakdown.Output,
-			CacheCreation: result.SessionBreakdown.CacheCreation,
-			CacheRead:     result.SessionBreakdown.CacheRead,
-		}
+		out.Session.Breakdown = result.SessionBreakdown.ToJSON()
 		out.Session.Limit = result.SessionLimit
 		out.Session.Ratio = result.SessionRatio
 		if result.SessionEndsAt != nil {

--- a/internal/blocks/blocks.go
+++ b/internal/blocks/blocks.go
@@ -22,6 +22,24 @@ func (t TokenBreakdown) Total() int {
 	return t.Input + t.Output + t.CacheCreation + t.CacheRead
 }
 
+// TokenBreakdownJSON is the JSON-serializable form of TokenBreakdown.
+type TokenBreakdownJSON struct {
+	Input         int `json:"input"`
+	Output        int `json:"output"`
+	CacheCreation int `json:"cache_creation"`
+	CacheRead     int `json:"cache_read"`
+}
+
+// ToJSON converts t to its JSON-serializable form.
+func (t TokenBreakdown) ToJSON() TokenBreakdownJSON {
+	return TokenBreakdownJSON{
+		Input:         t.Input,
+		Output:        t.Output,
+		CacheCreation: t.CacheCreation,
+		CacheRead:     t.CacheRead,
+	}
+}
+
 // Block represents a 5-hour billing period.
 type Block struct {
 	StartTime   time.Time

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/rengotaku/claude-usage-tracker/internal/blocks"
 	"github.com/rengotaku/claude-usage-tracker/internal/repository"
 )
 
@@ -72,22 +73,15 @@ func writeError(w http.ResponseWriter, status int, msg string) {
 
 // --- /usage/snapshots ---
 
-type tokenBreakdown struct {
-	Input         int `json:"input"`
-	Output        int `json:"output"`
-	CacheCreation int `json:"cache_creation"`
-	CacheRead     int `json:"cache_read"`
-}
-
 type snapshotItem struct {
-	TakenAt            string          `json:"taken_at"`
-	BlockStartedAt     string          `json:"block_started_at"`
-	BlockEndedAt       string          `json:"block_ended_at,omitempty"`
-	SessionTokens      int             `json:"session_tokens"`
-	Tokens             tokenBreakdown  `json:"tokens"`
-	SessionRatio       float64         `json:"session_ratio"`
-	WeeklyTokens       int             `json:"weekly_tokens"`
-	WeeklySonnetTokens int             `json:"weekly_sonnet_tokens"`
+	TakenAt            string                  `json:"taken_at"`
+	BlockStartedAt     string                  `json:"block_started_at"`
+	BlockEndedAt       string                  `json:"block_ended_at,omitempty"`
+	SessionTokens      int                     `json:"session_tokens"`
+	Tokens             blocks.TokenBreakdownJSON `json:"tokens"`
+	SessionRatio       float64                 `json:"session_ratio"`
+	WeeklyTokens       int                     `json:"weekly_tokens"`
+	WeeklySonnetTokens int                     `json:"weekly_sonnet_tokens"`
 }
 
 type snapshotsResponse struct {
@@ -114,15 +108,10 @@ func (h *Handler) Snapshots(w http.ResponseWriter, r *http.Request) {
 	items := make([]snapshotItem, 0, len(snaps))
 	for _, s := range snaps {
 		item := snapshotItem{
-			TakenAt:        s.TakenAt.In(jst).Format(jsonTimeFormat),
-			BlockStartedAt: s.BlockStartedAt.In(jst).Format(jsonTimeFormat),
-			SessionTokens:  s.TokensUsed,
-			Tokens: tokenBreakdown{
-				Input:         s.Tokens.Input,
-				Output:        s.Tokens.Output,
-				CacheCreation: s.Tokens.CacheCreation,
-				CacheRead:     s.Tokens.CacheRead,
-			},
+			TakenAt:            s.TakenAt.In(jst).Format(jsonTimeFormat),
+			BlockStartedAt:     s.BlockStartedAt.In(jst).Format(jsonTimeFormat),
+			SessionTokens:      s.TokensUsed,
+			Tokens:             s.Tokens.ToJSON(),
 			SessionRatio:       s.UsageRatio,
 			WeeklyTokens:       s.WeeklyTokens,
 			WeeklySonnetTokens: s.WeeklySonnetTokens,


### PR DESCRIPTION
## Summary

Closes #86

- `internal/server/handlers.go` の `tokenBreakdown` struct と `cmd/current/main.go` の `tokenBreakdownJSON` struct が同一フィールド・同一 JSON タグで二重定義されていた
- `blocks.TokenBreakdownJSON` 型と `TokenBreakdown.ToJSON()` メソッドを追加し、両者を一元化
- インライン変換を `s.Tokens.ToJSON()` / `result.SessionBreakdown.ToJSON()` に置き換え

## Changes

- `internal/blocks/blocks.go`: `TokenBreakdownJSON` struct と `ToJSON()` メソッドを追加
- `internal/server/handlers.go`: ローカル `tokenBreakdown` struct を削除、`blocks.TokenBreakdownJSON` を使用
- `cmd/current/main.go`: ローカル `tokenBreakdownJSON` struct を削除、`blocks.TokenBreakdownJSON` を使用

## Test plan

- [ ] `go build ./...` が通ること
- [ ] `go test ./...` が全パスすること
- [ ] `/usage/snapshots` API のレスポンス JSON スキーマが変わらないこと
- [ ] `claude-usage-tracker-current --json` の出力スキーマが変わらないこと