### PR TITLE
refactor: totalTokens の重複を UsageEntry.TotalTokens() メソッドに統合

### DIFF
--- a/cmd/report/main.go
+++ b/cmd/report/main.go
@@ -119,7 +119,7 @@ func computeModelBreakdown(entries []jsonl.UsageEntry, weekStart time.Time) map[
 		if e.Timestamp.Before(weekStart) {
 			continue
 		}
-		byModel[report.ClassifyModel(e.Model)] += report.TotalTokens(e)
+		byModel[report.ClassifyModel(e.Model)] += e.TotalTokens()
 	}
 	return byModel
 }

--- a/internal/blocks/blocks.go
+++ b/internal/blocks/blocks.go
@@ -59,7 +59,7 @@ func Build(entries []jsonl.UsageEntry) []Block {
 			blocks = append(blocks, b)
 			current = &blocks[len(blocks)-1]
 		}
-		current.TotalTokens += totalTokens(e)
+		current.TotalTokens += e.TotalTokens()
 		current.Tokens.Input += e.InputTokens
 		current.Tokens.Output += e.OutputTokens
 		current.Tokens.CacheCreation += e.CacheCreationInputTokens
@@ -93,9 +93,4 @@ func ActiveBlock(blocks []Block) *Block {
 		}
 	}
 	return nil
-}
-
-
-func totalTokens(e jsonl.UsageEntry) int {
-	return e.InputTokens + e.OutputTokens + e.CacheCreationInputTokens + e.CacheReadInputTokens
 }

--- a/internal/jsonl/parser.go
+++ b/internal/jsonl/parser.go
@@ -21,6 +21,10 @@ type UsageEntry struct {
 	CacheReadInputTokens     int
 }
 
+func (e UsageEntry) TotalTokens() int {
+	return e.InputTokens + e.OutputTokens + e.CacheCreationInputTokens + e.CacheReadInputTokens
+}
+
 type rawEntry struct {
 	Type      string    `json:"type"`
 	UUID      string    `json:"uuid"`

--- a/internal/report/monthly.go
+++ b/internal/report/monthly.go
@@ -40,7 +40,7 @@ func ComputeMonthly(entries []jsonl.UsageEntry, now time.Time) *MonthlyData {
 		if ts.Before(prevStart) || !ts.Before(prevEnd) {
 			continue
 		}
-		t := TotalTokens(e)
+		t := e.TotalTokens()
 		total += t
 		byModel[ClassifyModel(e.Model)] += t
 	}
@@ -65,9 +65,4 @@ func ClassifyModel(model string) string {
 	default:
 		return "Other"
 	}
-}
-
-// TotalTokens returns the sum of all token types in a UsageEntry.
-func TotalTokens(e jsonl.UsageEntry) int {
-	return e.InputTokens + e.OutputTokens + e.CacheCreationInputTokens + e.CacheReadInputTokens
 }

--- a/internal/service/usage.go
+++ b/internal/service/usage.go
@@ -127,7 +127,7 @@ func Compute(cfg Config) (*UsageResult, error) {
 		if e.Timestamp.Before(weekStart) {
 			continue
 		}
-		t := totalTokens(e)
+		t := e.TotalTokens()
 		result.WeeklyTokens += t
 		if isSonnet(e.Model) {
 			result.WeeklySonnetTokens += t
@@ -163,10 +163,6 @@ func lastWeeklyReset(day time.Weekday, hour int) time.Time {
 
 func nextWeeklyReset(day time.Weekday, hour int) time.Time {
 	return lastWeeklyReset(day, hour).AddDate(0, 0, 7)
-}
-
-func totalTokens(e jsonl.UsageEntry) int {
-	return e.InputTokens + e.OutputTokens + e.CacheCreationInputTokens + e.CacheReadInputTokens
 }
 
 func isSonnet(model string) bool {


### PR DESCRIPTION
## Summary

Closes #94

- `internal/blocks/blocks.go`、`internal/service/usage.go`、`internal/report/monthly.go` の3箇所に重複していた `totalTokens(e jsonl.UsageEntry) int` 関数を削除
- `jsonl.UsageEntry` 型に `TotalTokens()` メソッドを追加して一元化
- 全呼び出し箇所を `e.TotalTokens()` に置き換え

## Test plan

- [ ] `go build ./...` が成功すること
- [ ] `go test ./...` が全パス (`internal/blocks`, `internal/service`, `internal/report`, `internal/jsonl`) で通ること
- [ ] `report.TotalTokens` への参照が残っていないこと (`grep -r "report\.TotalTokens"` で確認)