### PR TITLE
refactor: JST タイムゾーン定義を internal/tz パッケージに集約する

### DIFF
--- a/cmd/current/main.go
+++ b/cmd/current/main.go
@@ -15,9 +15,9 @@ import (
 	"github.com/rengotaku/claude-usage-tracker/internal/logging"
 	"github.com/rengotaku/claude-usage-tracker/internal/numfmt"
 	"github.com/rengotaku/claude-usage-tracker/internal/service"
+	"github.com/rengotaku/claude-usage-tracker/internal/tz"
 )
 
-var jst = time.FixedZone("JST", 9*60*60)
 
 type tokenBreakdownJSON struct {
 	Input         int `json:"input"`
@@ -109,7 +109,7 @@ func main() {
 		out.Session.Limit = result.SessionLimit
 		out.Session.Ratio = result.SessionRatio
 		if result.SessionEndsAt != nil {
-			out.Session.EndsAt = result.SessionEndsAt.In(jst).Format(time.RFC3339)
+			out.Session.EndsAt = result.SessionEndsAt.In(tz.JST).Format(time.RFC3339)
 		}
 		out.Weekly.TokensUsed = result.WeeklyTokens
 		out.Weekly.Limit = result.WeeklyLimit
@@ -117,7 +117,7 @@ func main() {
 		out.Weekly.SonnetTokens = result.WeeklySonnetTokens
 		out.Weekly.SonnetLimit = result.WeeklySonnetLimit
 		out.Weekly.SonnetRatio = result.WeeklySonnetRatio
-		out.Weekly.ResetsAt = result.WeeklyResetsAt.In(jst).Format(time.RFC3339)
+		out.Weekly.ResetsAt = result.WeeklyResetsAt.In(tz.JST).Format(time.RFC3339)
 		if len(result.WeeklyModelBreakdown) > 0 {
 			out.Weekly.ModelBreakdown = make(map[string]tokenBreakdownJSON, len(result.WeeklyModelBreakdown))
 			for model, bd := range result.WeeklyModelBreakdown {
@@ -134,7 +134,7 @@ func main() {
 		return
 	}
 
-	resetsAt := result.WeeklyResetsAt.In(jst).Format("Jan 2, 3pm")
+	resetsAt := result.WeeklyResetsAt.In(tz.JST).Format("Jan 2, 3pm")
 	fmt.Printf("Current session   %s\n", sessionLine(result))
 	b := result.SessionBreakdown
 	fmt.Printf("  input %-8s  output %-8s  cache_creation %-8s  cache_read %s\n",
@@ -159,7 +159,7 @@ func main() {
 func sessionLine(r *service.UsageResult) string {
 	endsAt := ""
 	if r.SessionEndsAt != nil {
-		endsAt = ", resets " + r.SessionEndsAt.In(jst).Format("3pm (Asia/Tokyo)")
+		endsAt = ", resets " + r.SessionEndsAt.In(tz.JST).Format("3pm (Asia/Tokyo)")
 	}
 	if r.SessionLimit > 0 {
 		pct := r.SessionRatio * 100

--- a/cmd/report/main.go
+++ b/cmd/report/main.go
@@ -13,9 +13,9 @@ import (
 	"github.com/rengotaku/claude-usage-tracker/internal/logging"
 	"github.com/rengotaku/claude-usage-tracker/internal/report"
 	"github.com/rengotaku/claude-usage-tracker/internal/service"
+	"github.com/rengotaku/claude-usage-tracker/internal/tz"
 )
 
-var jst = time.FixedZone("JST", 9*60*60)
 
 const lastReportFile = ".local/share/claude-usage-tracker/last-usage-report.txt"
 
@@ -54,7 +54,7 @@ func main() {
 
 	recentBlocks := buildRecentBlocks(entries)
 
-	now := time.Now().In(jst)
+	now := time.Now().In(tz.JST)
 	monthly := report.ComputeMonthly(entries, now)
 
 	osType := "linux"

--- a/internal/report/builder.go
+++ b/internal/report/builder.go
@@ -9,9 +9,9 @@ import (
 	"github.com/rengotaku/claude-usage-tracker/internal/blocks"
 	"github.com/rengotaku/claude-usage-tracker/internal/numfmt"
 	"github.com/rengotaku/claude-usage-tracker/internal/service"
+	"github.com/rengotaku/claude-usage-tracker/internal/tz"
 )
 
-var jst = time.FixedZone("JST", 9*60*60)
 
 // Input holds all data needed to render a weekly usage report.
 type Input struct {
@@ -25,7 +25,7 @@ type Input struct {
 
 // Build renders the Markdown report body.
 func Build(in Input) string {
-	nowStr := in.Now.In(jst).Format("2006-01-02 15:04 JST")
+	nowStr := in.Now.In(tz.JST).Format("2006-01-02 15:04 JST")
 	var sb strings.Builder
 
 	fmt.Fprintf(&sb, "## 週次レポート — %s\n\n", nowStr)
@@ -49,7 +49,7 @@ func buildSession(u *service.UsageResult) string {
 		usageLine = fmt.Sprintf("%s (%s / %s)", fmtPct(u.SessionRatio), numfmt.Tokens(u.SessionTokens), numfmt.Tokens(u.SessionLimit))
 	}
 	if u.SessionEndsAt != nil {
-		usageLine += fmt.Sprintf(" — ブロック終了: %s", u.SessionEndsAt.In(jst).Format(time.RFC3339))
+		usageLine += fmt.Sprintf(" — ブロック終了: %s", u.SessionEndsAt.In(tz.JST).Format(time.RFC3339))
 	}
 	fmt.Fprintf(&sb, "- 使用率: %s\n\n", usageLine)
 
@@ -73,7 +73,7 @@ func buildWeekly(u *service.UsageResult, modelBreakdown map[string]int) string {
 	if u.WeeklySonnetLimit > 0 {
 		sonnetLine = fmt.Sprintf("%s (%s / %s)", fmtPct(u.WeeklySonnetRatio), numfmt.Tokens(u.WeeklySonnetTokens), numfmt.Tokens(u.WeeklySonnetLimit))
 	}
-	resetsAt := u.WeeklyResetsAt.In(jst).Format(time.RFC3339)
+	resetsAt := u.WeeklyResetsAt.In(tz.JST).Format(time.RFC3339)
 
 	fmt.Fprintf(&sb, "- All: %s\n", allLine)
 	fmt.Fprintf(&sb, "- Sonnet: %s\n", sonnetLine)
@@ -112,12 +112,12 @@ func buildBlocks(bs []blocks.Block) string {
 	sb.WriteString("| 開始 (JST) | 終了 (JST) | トークン |\n")
 	sb.WriteString("|------------|------------|----------|\n")
 	for _, b := range bs {
-		end := b.EndTime.In(jst).Format("2006-01-02 15:04")
+		end := b.EndTime.In(tz.JST).Format("2006-01-02 15:04")
 		if b.IsActive {
 			end = "進行中"
 		}
 		fmt.Fprintf(&sb, "| %s | %s | %s |\n",
-			b.StartTime.In(jst).Format("2006-01-02 15:04"),
+			b.StartTime.In(tz.JST).Format("2006-01-02 15:04"),
 			end,
 			numfmt.Tokens(b.TotalTokens),
 		)

--- a/internal/report/builder_test.go
+++ b/internal/report/builder_test.go
@@ -8,12 +8,12 @@ import (
 	"github.com/rengotaku/claude-usage-tracker/internal/blocks"
 	"github.com/rengotaku/claude-usage-tracker/internal/report"
 	"github.com/rengotaku/claude-usage-tracker/internal/service"
+	"github.com/rengotaku/claude-usage-tracker/internal/tz"
 )
 
-var jst = time.FixedZone("JST", 9*60*60)
 
 func fixedTime(year, month, day, hour int) time.Time {
-	return time.Date(year, time.Month(month), day, hour, 0, 0, 0, jst)
+	return time.Date(year, time.Month(month), day, hour, 0, 0, 0, tz.JST)
 }
 
 func TestBuild_ContainsHeader(t *testing.T) {

--- a/internal/server/aggregation.go
+++ b/internal/server/aggregation.go
@@ -5,9 +5,9 @@ import (
 	"time"
 
 	"github.com/rengotaku/claude-usage-tracker/internal/repository"
+	"github.com/rengotaku/claude-usage-tracker/internal/tz"
 )
 
-var jst = time.FixedZone("JST", 9*60*60)
 
 // BlockAgg represents a 5-hour block aggregation derived from snapshots.
 type BlockAgg struct {
@@ -65,7 +65,7 @@ func AggregateDaily(blocks []BlockAgg) []DailyAgg {
 	}
 	byDate := make(map[string]*DailyAgg)
 	for _, b := range blocks {
-		d := b.Start.In(jst).Format("2006-01-02")
+		d := b.Start.In(tz.JST).Format("2006-01-02")
 		agg, ok := byDate[d]
 		if !ok {
 			agg = &DailyAgg{Date: d}

--- a/internal/server/handlers.go
+++ b/internal/server/handlers.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/rengotaku/claude-usage-tracker/internal/blocks"
 	"github.com/rengotaku/claude-usage-tracker/internal/repository"
+	"github.com/rengotaku/claude-usage-tracker/internal/tz"
 )
 
 // timeFormat for JSON output (JST).
@@ -19,7 +20,7 @@ type errorResponse struct {
 
 // formatJST renders t in JST using jsonTimeFormat.
 func formatJST(t time.Time) string {
-	return t.In(jst).Format(jsonTimeFormat)
+	return t.In(tz.JST).Format(jsonTimeFormat)
 }
 
 // newPeriod builds a periodDTO from a [from, to] pair.
@@ -86,7 +87,7 @@ func parseFlexibleTime(v string, endOfDay bool) (time.Time, error) {
 	if t, err := time.Parse(time.RFC3339, v); err == nil {
 		return t.UTC(), nil
 	}
-	if t, err := time.ParseInLocation("2006-01-02", v, jst); err == nil {
+	if t, err := time.ParseInLocation("2006-01-02", v, tz.JST); err == nil {
 		if endOfDay {
 			t = t.Add(24*time.Hour - time.Second)
 		}

--- a/internal/service/usage.go
+++ b/internal/service/usage.go
@@ -9,9 +9,9 @@ import (
 	"github.com/rengotaku/claude-usage-tracker/internal/config"
 	"github.com/rengotaku/claude-usage-tracker/internal/jsonl"
 	"github.com/rengotaku/claude-usage-tracker/internal/plan"
+	"github.com/rengotaku/claude-usage-tracker/internal/tz"
 )
 
-var jst = time.FixedZone("JST", 9*60*60)
 
 var weekdayNames = map[string]time.Weekday{
 	"sunday": time.Sunday, "monday": time.Monday, "tuesday": time.Tuesday,
@@ -164,9 +164,9 @@ func Compute(cfg Config) (*UsageResult, error) {
 }
 
 func lastWeeklyReset(day time.Weekday, hour int) time.Time {
-	now := time.Now().In(jst)
+	now := time.Now().In(tz.JST)
 	daysSince := (int(now.Weekday()) - int(day) + 7) % 7
-	reset := time.Date(now.Year(), now.Month(), now.Day()-daysSince, hour, 0, 0, 0, jst)
+	reset := time.Date(now.Year(), now.Month(), now.Day()-daysSince, hour, 0, 0, 0, tz.JST)
 	if now.Before(reset) {
 		reset = reset.AddDate(0, 0, -7)
 	}

--- a/internal/tz/tz.go
+++ b/internal/tz/tz.go
@@ -1,0 +1,6 @@
+package tz
+
+import "time"
+
+// JST is the Japan Standard Time timezone (UTC+9).
+var JST = time.FixedZone("JST", 9*60*60)


### PR DESCRIPTION
## 概要

Closes #95

6箇所で重複定義されていた JST タイムゾーン変数を `internal/tz` パッケージに集約した。

- `internal/tz/tz.go` を新規作成し `tz.JST` をエクスポート
- 各ファイルの `var jst = time.FixedZone("JST", 9*60*60)` を削除し `tz.JST` を参照するよう変更

## 変更ファイル

- `internal/tz/tz.go` (新規)
- `internal/server/aggregation.go`
- `internal/server/handlers.go`
- `internal/report/builder.go`
- `internal/service/usage.go`
- `cmd/current/main.go`
- `cmd/report/main.go`

## テスト計画

- [x] `go build ./...` が成功すること
- [x] `go test ./...` が全パス通ること