### PR TITLE
[WIP] refactor: JST タイムゾーン定義を internal/timezone パッケージに統合する

### DIFF
--- a/cmd/current/main.go
+++ b/cmd/current/main.go
@@ -11,9 +11,10 @@ import (
 	"github.com/rengotaku/claude-usage-tracker/internal/cache"
 	"github.com/rengotaku/claude-usage-tracker/internal/config"
 	"github.com/rengotaku/claude-usage-tracker/internal/service"
+	"github.com/rengotaku/claude-usage-tracker/internal/timezone"
 )
 
-var jst = time.FixedZone("JST", 9*60*60)
+var jst = timezone.JST
 
 type tokenBreakdownJSON struct {
 	Input         int `json:"input"`

--- a/internal/server/aggregation.go
+++ b/internal/server/aggregation.go
@@ -5,9 +5,10 @@ import (
 	"time"
 
 	"github.com/rengotaku/claude-usage-tracker/internal/repository"
+	"github.com/rengotaku/claude-usage-tracker/internal/timezone"
 )
 
-var jst = time.FixedZone("JST", 9*60*60)
+var jst = timezone.JST
 
 // BlockAgg represents a 5-hour block aggregation derived from snapshots.
 type BlockAgg struct {

--- a/internal/service/usage.go
+++ b/internal/service/usage.go
@@ -9,9 +9,10 @@ import (
 	"github.com/rengotaku/claude-usage-tracker/internal/config"
 	"github.com/rengotaku/claude-usage-tracker/internal/jsonl"
 	"github.com/rengotaku/claude-usage-tracker/internal/plan"
+	"github.com/rengotaku/claude-usage-tracker/internal/timezone"
 )
 
-var jst = time.FixedZone("JST", 9*60*60)
+var jst = timezone.JST
 
 var weekdayNames = map[string]time.Weekday{
 	"sunday": time.Sunday, "monday": time.Monday, "tuesday": time.Tuesday,

--- a/internal/timezone/timezone.go
+++ b/internal/timezone/timezone.go
@@ -1,0 +1,6 @@
+package timezone
+
+import "time"
+
+// JST is the Japan Standard Time zone (UTC+9).
+var JST = time.FixedZone("JST", 9*60*60)


### PR DESCRIPTION
## 概要

3ファイルで重複していた `var jst = time.FixedZone("JST", 9*60*60)` を `internal/timezone` パッケージに統合。

## 変更内容

- `internal/timezone/timezone.go` を新規作成し `JST` 変数を一元定義
- 以下3ファイルの重複定義を削除し `timezone.JST` を参照するよう変更
  - `internal/server/aggregation.go`
  - `internal/service/usage.go`
  - `cmd/current/main.go`

## テスト計画

- [x] `go build ./...` パス
- [x] `go test ./...` 全テストパス

Closes #106