### PR TITLE
refactor: totalTokens 関数の重複を UsageEntry.TotalTokens() メソッドに統一する

### DIFF
--- a/cmd/report/main.go
+++ b/cmd/report/main.go
@@ -119,7 +119,7 @@ func computeModelBreakdown(entries []jsonl.UsageEntry, weekStart time.Time) map[
 		if e.Timestamp.Before(weekStart) {
 			continue
 		}
-		byModel[report.ClassifyModel(e.Model)] += report.TotalTokens(e)
+		byModel[report.ClassifyModel(e.Model)] += e.TotalTokens()
 	}
 	return byModel
 }

--- a/internal/blocks/blocks.go
+++ b/internal/blocks/blocks.go
@@ -59,7 +59,7 @@ func Build(entries []jsonl.UsageEntry) []Block {
 			blocks = append(blocks, b)
 			current = &blocks[len(blocks)-1]
 		}
-		current.TotalTokens += totalTokens(e)
+		current.TotalTokens += e.TotalTokens()
 		current.Tokens.Input += e.InputTokens
 		current.Tokens.Output += e.OutputTokens
 		current.Tokens.CacheCreation += e.CacheCreationInputTokens
@@ -93,9 +93,4 @@ func ActiveBlock(blocks []Block) *Block {
 		}
 	}
 	return nil
-}
-
-
-func totalTokens(e jsonl.UsageEntry) int {
-	return e.InputTokens + e.OutputTokens + e.CacheCreationInputTokens + e.CacheReadInputTokens
 }

--- a/internal/jsonl/parser.go
+++ b/internal/jsonl/parser.go
@@ -21,6 +21,11 @@ type UsageEntry struct {
 	CacheReadInputTokens     int
 }
 
+// TotalTokens returns the sum of all token types in the entry.
+func (e UsageEntry) TotalTokens() int {
+	return e.InputTokens + e.OutputTokens + e.CacheCreationInputTokens + e.CacheReadInputTokens
+}
+
 type rawEntry struct {
 	Type      string    `json:"type"`
 	UUID      string    `json:"uuid"`

--- a/internal/jsonl/parser_test.go
+++ b/internal/jsonl/parser_test.go
@@ -77,6 +77,18 @@ func TestParse_NonExistentDir(t *testing.T) {
 	}
 }
 
+func TestUsageEntry_TotalTokens(t *testing.T) {
+	e := jsonl.UsageEntry{
+		InputTokens:              10,
+		OutputTokens:             20,
+		CacheCreationInputTokens: 100,
+		CacheReadInputTokens:     50,
+	}
+	if got := e.TotalTokens(); got != 180 {
+		t.Errorf("TotalTokens() = %d, want 180", got)
+	}
+}
+
 func TestParse_SkipsMalformedLines(t *testing.T) {
 	// sample.jsonl contains one malformed line; Parse should not return error
 	entries, err := jsonl.Parse("testdata")

--- a/internal/jsonl/parser_test.go
+++ b/internal/jsonl/parser_test.go
@@ -78,14 +78,21 @@ func TestParse_NonExistentDir(t *testing.T) {
 }
 
 func TestUsageEntry_TotalTokens(t *testing.T) {
-	e := jsonl.UsageEntry{
-		InputTokens:              10,
-		OutputTokens:             20,
-		CacheCreationInputTokens: 100,
-		CacheReadInputTokens:     50,
+	tests := []struct {
+		name string
+		e    jsonl.UsageEntry
+		want int
+	}{
+		{"all fields", jsonl.UsageEntry{InputTokens: 10, OutputTokens: 20, CacheCreationInputTokens: 100, CacheReadInputTokens: 50}, 180},
+		{"zeros", jsonl.UsageEntry{}, 0},
+		{"only input", jsonl.UsageEntry{InputTokens: 5}, 5},
 	}
-	if got := e.TotalTokens(); got != 180 {
-		t.Errorf("TotalTokens() = %d, want 180", got)
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.e.TotalTokens(); got != tt.want {
+				t.Errorf("TotalTokens() = %d, want %d", got, tt.want)
+			}
+		})
 	}
 }
 

--- a/internal/report/monthly.go
+++ b/internal/report/monthly.go
@@ -40,7 +40,7 @@ func ComputeMonthly(entries []jsonl.UsageEntry, now time.Time) *MonthlyData {
 		if ts.Before(prevStart) || !ts.Before(prevEnd) {
 			continue
 		}
-		t := TotalTokens(e)
+		t := e.TotalTokens()
 		total += t
 		byModel[ClassifyModel(e.Model)] += t
 	}
@@ -65,9 +65,4 @@ func ClassifyModel(model string) string {
 	default:
 		return "Other"
 	}
-}
-
-// TotalTokens returns the sum of all token types in a UsageEntry.
-func TotalTokens(e jsonl.UsageEntry) int {
-	return e.InputTokens + e.OutputTokens + e.CacheCreationInputTokens + e.CacheReadInputTokens
 }

--- a/internal/service/usage.go
+++ b/internal/service/usage.go
@@ -127,7 +127,7 @@ func Compute(cfg Config) (*UsageResult, error) {
 		if e.Timestamp.Before(weekStart) {
 			continue
 		}
-		t := totalTokens(e)
+		t := e.TotalTokens()
 		result.WeeklyTokens += t
 		if isSonnet(e.Model) {
 			result.WeeklySonnetTokens += t
@@ -163,10 +163,6 @@ func lastWeeklyReset(day time.Weekday, hour int) time.Time {
 
 func nextWeeklyReset(day time.Weekday, hour int) time.Time {
 	return lastWeeklyReset(day, hour).AddDate(0, 0, 7)
-}
-
-func totalTokens(e jsonl.UsageEntry) int {
-	return e.InputTokens + e.OutputTokens + e.CacheCreationInputTokens + e.CacheReadInputTokens
 }
 
 func isSonnet(model string) bool {


### PR DESCRIPTION
## 概要

closes #104

`totalTokens(e jsonl.UsageEntry) int` と同等のロジックが3箇所に重複していたため、`jsonl.UsageEntry` にメソッドとして統一した。

## 変更内容

- `internal/jsonl/parser.go`: `UsageEntry.TotalTokens()` メソッドを追加
- `internal/blocks/blocks.go`: private `totalTokens` 関数を削除 → `e.TotalTokens()` に置き換え
- `internal/service/usage.go`: private `totalTokens` 関数を削除 → `e.TotalTokens()` に置き換え
- `internal/report/monthly.go`: exported `TotalTokens` 関数を削除 → `e.TotalTokens()` に置き換え
- `cmd/report/main.go`: `report.TotalTokens(e)` → `e.TotalTokens()` に更新
- `internal/jsonl/parser_test.go`: `TotalTokens()` のユニットテストを追加

## テスト計画

- [x] `go build ./...` が通ること
- [x] `go test ./...` が全パス通ること
- [x] `internal/jsonl.TestUsageEntry_TotalTokens` で計算ロジックを検証
